### PR TITLE
Return cloned responses from deduped fetches

### DIFF
--- a/src/js/utils/cache.js
+++ b/src/js/utils/cache.js
@@ -98,10 +98,11 @@ export function getCached(key, withMeta = false) {
 
 export function fetchDedup(url, options = {}) {
   const key = requestKey(url, options);
-  if (inFlight.has(key)) return inFlight.get(key);
-  const promise = fetchWithRetry(url, options).finally(() => inFlight.delete(key));
-  inFlight.set(key, promise);
-  return promise;
+  const base =
+    inFlight.get(key) ||
+    fetchWithRetry(url, options).finally(() => inFlight.delete(key));
+  inFlight.set(key, base);
+  return base.then((res) => res.clone());
 }
 
 export default {


### PR DESCRIPTION
## Summary
- Ensure `fetchDedup` clones responses so multiple consumers can safely read the body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af878779988328a4d0501f561bf580