### PR TITLE
feat: add fallback mode handling in compare UI

### DIFF
--- a/src/js/compare-ui.js
+++ b/src/js/compare-ui.js
@@ -132,14 +132,20 @@ if (!window._modeChangeHandlerInstalled) {
 
       // Usa una función de búsqueda que opere dentro del árbol del nodo raíz
       const ingredient = findIngredientByPath([rootNode], pathArr);
-      
+
       if (ingredient) {
         let newMode = 'buy';
         if (target.classList.contains('chk-mode-sell')) newMode = 'sell';
         if (target.classList.contains('chk-mode-crafted')) newMode = 'crafted';
-        
-        // Llamamos al nuevo método que se encarga de todo: recalcular y volver a renderizar
-        ingredient.setMode(newMode);
+        // Llamamos al nuevo método si está disponible, sino ajustamos manualmente
+        if (typeof ingredient.setMode === 'function') {
+          // Llamamos al nuevo método que se encarga de todo: recalcular y volver a renderizar
+          ingredient.setMode(newMode);
+        } else {
+          ingredient.modeForParentCrafted = newMode;
+          ingredient.findRoot()?.recalc(window.globalQty || 1, null);
+          if (typeof safeRenderTable === 'function') safeRenderTable();
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- handle `.chk-mode-*` clicks using `findIngredientByPath`
- gracefully handle ingredients without `setMode` by updating `modeForParentCrafted`, recalculating, and re-rendering

## Testing
- `npm test` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcfd94ec08328b21416c68ddb78b7