### PR TITLE
fix: scale nested component prices in crafting calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rm -rf dist/js dist/manifest.json && npm run build:packages && APP_VERSION=v$(git rev-parse --short HEAD) && sed \"s/__APP_VERSION__/$APP_VERSION/\" service-worker.js > service-worker.build.js && npx terser service-worker.build.js -o service-worker.min.js && rm service-worker.build.js && rollup -c",
     "migrate:mongo": "node backend/setup.mongo.js",
     "jobs": "node backend/jobs/index.js",
-    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/check-assets.mjs",
+    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",

--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -3225,7 +3225,12 @@ class LegendaryCraftingBase {
       const sellPrice = component.sellPrice > 0 ? component.sellPrice * component.count : 0;
       if ((buyPrice === 0 || sellPrice === 0) && component.components && component.components.length > 0) {
         const compPrices = this.calculateComponentsPrice(component);
-        return { buy: totals.buy + (buyPrice > 0 ? buyPrice : compPrices.buy), sell: totals.sell + (sellPrice > 0 ? sellPrice : compPrices.sell) };
+        const scaledBuy = compPrices.buy * component.count;
+        const scaledSell = compPrices.sell * component.count;
+        return {
+          buy: totals.buy + (buyPrice > 0 ? buyPrice : scaledBuy),
+          sell: totals.sell + (sellPrice > 0 ? sellPrice : scaledSell)
+        };
       }
       return { buy: totals.buy + buyPrice, sell: totals.sell + sellPrice };
     }, { buy: 0, sell: 0 });

--- a/tests/calculateComponentsPrice.test.mjs
+++ b/tests/calculateComponentsPrice.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'assert'
+
+global.window = {}
+global.document = {
+  getElementById: () => null,
+  querySelectorAll: () => []
+}
+
+await import('../src/js/bundle-legendary.js')
+const { LegendaryCraftingBase } = window.LegendaryUtils
+const calc = new LegendaryCraftingBase({})
+
+// Component with direct prices
+const directTree = {
+  components: [
+    { buyPrice: 1, sellPrice: 2, count: 3, components: [] }
+  ]
+}
+assert.deepStrictEqual(calc.calculateComponentsPrice(directTree), { buy: 3, sell: 6 })
+
+// Component without direct price but with nested components
+const nestedTree = {
+  components: [
+    {
+      buyPrice: 0,
+      sellPrice: 0,
+      count: 2,
+      components: [
+        { buyPrice: 5, sellPrice: 6, count: 1, components: [] }
+      ]
+    }
+  ]
+}
+assert.deepStrictEqual(calc.calculateComponentsPrice(nestedTree), { buy: 10, sell: 12 })
+
+// Mixed tree
+const mixedTree = {
+  components: [
+    { buyPrice: 1, sellPrice: 2, count: 3, components: [] },
+    {
+      buyPrice: 0,
+      sellPrice: 0,
+      count: 2,
+      components: [
+        { buyPrice: 5, sellPrice: 6, count: 1, components: [] }
+      ]
+    }
+  ]
+}
+assert.deepStrictEqual(calc.calculateComponentsPrice(mixedTree), { buy: 13, sell: 18 })
+
+console.log('calculateComponentsPrice test passed')


### PR DESCRIPTION
## Summary
- multiply nested component totals by quantity in `calculateComponentsPrice`
- add unit tests covering components with direct prices and nested components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff1e24f088328b85b5a330ea324ba