### PR TITLE
Fix countTotal scaling for multi-output recipes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rm -rf dist/js dist/manifest.json && npm run build:packages && APP_VERSION=v$(git rev-parse --short HEAD) && sed \"s/__APP_VERSION__/$APP_VERSION/\" service-worker.js > service-worker.build.js && npx terser service-worker.build.js -o service-worker.min.js && rm service-worker.build.js && rollup -c",
     "migrate:mongo": "node backend/setup.mongo.js",
     "jobs": "node backend/jobs/index.js",
-    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs",
+    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",

--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -67,7 +67,8 @@ export class CraftIngredient {
     if (isRoot) {
       this.countTotal = this.count * globalQty;
     } else {
-      this.countTotal = parent.countTotal * this.count;
+      const parentOutput = parent.recipe?.output_item_count || parent.parentMultiplier || 1;
+      this.countTotal = (parent.countTotal * this.count) / parentOutput;
     }
 
     if (this.children && this.children.length > 0) {

--- a/tests/dones-worker.test.mjs
+++ b/tests/dones-worker.test.mjs
@@ -1,51 +1,85 @@
-import { adaptNode } from '../src/js/workers/donesWorker.js';
+import assert from 'assert';
 import { rebuildTreeArray, recalcAll, getTotals } from '../src/js/workers/costsWorker.js';
 
 function manualTotals(tree, globalQty) {
-  function traverse(node, parentQty) {
-    const countTotal = node.count * parentQty;
+  function traverse(node, parent) {
+    const parentCount = parent ? parent.countTotal : globalQty;
+    const divisor = parent ? (parent.recipe?.output_item_count || parent.parentMultiplier || 1) : 1;
+    const countTotal = parent ? (parentCount * node.count) / divisor : node.count * globalQty;
     let totalBuy = (node.buy_price || 0) * countTotal;
     let totalSell = (node.sell_price || 0) * countTotal;
     if (Array.isArray(node.children)) {
       for (const child of node.children) {
-        const res = traverse(child, countTotal);
+        node.countTotal = countTotal;
+        const res = traverse(child, node);
         totalBuy += res.totalBuy;
         totalSell += res.totalSell;
       }
     }
+    node.countTotal = countTotal;
     node.total_buy = totalBuy;
     node.total_sell = totalSell;
-    return { totalBuy, totalSell };
+    if (node.is_craftable && node.children && node.children.length > 0) {
+      node.total_crafted = node.children.reduce((sum, ing) => {
+        switch (ing.modeForParentCrafted) {
+          case 'sell': return sum + (ing.total_sell || 0);
+          case 'crafted': return sum + (ing.total_crafted || 0);
+          default: return sum + (ing.total_buy || 0);
+        }
+      }, 0);
+    } else {
+      node.total_crafted = null;
+    }
+    return { totalBuy, totalSell, totalCrafted: node.total_crafted }; 
   }
-  const totals = { totalBuy: 0, totalSell: 0 };
+  const totals = { totalBuy: 0, totalSell: 0, totalCrafted: 0 };
   for (const ing of tree) {
-    const res = traverse(ing, globalQty);
+    const res = traverse(ing, null);
     totals.totalBuy += res.totalBuy;
     totals.totalSell += res.totalSell;
+    switch (ing.modeForParentCrafted) {
+      case 'sell':
+        totals.totalCrafted += ing.total_sell || 0;
+        break;
+      case 'crafted':
+        totals.totalCrafted += ing.total_crafted || 0;
+        break;
+      default:
+        totals.totalCrafted += ing.total_buy || 0;
+        break;
+    }
   }
   return totals;
 }
 
-async function main() {
-  const sample = [
-    {
-      id: 19675,
-      name: 'Trébol místico',
-      count: 1,
-      components: [
-        { id: 19976, name: 'Moneda mística', count: 2 },
-        { id: 19721, name: 'Pegote de ectoplasma', count: 3 }
-      ]
-    },
-    { id: 19721, name: 'Pegote de ectoplasma', count: 4 }
-  ];
-  const ingredientTree = await Promise.all(sample.map(ing => adaptNode(ing, null)));
-  const manual = manualTotals(JSON.parse(JSON.stringify(ingredientTree)), 1);
-  const objs = rebuildTreeArray(JSON.parse(JSON.stringify(ingredientTree)));
-  recalcAll(objs, 1);
-  const totals = getTotals(objs);
-  console.log('manual totals', manual);
-  console.log('worker totals', totals);
-}
+const sample = [
+  {
+    id: 1,
+    name: 'Root',
+    count: 1,
+    is_craftable: true,
+    recipe: { output_item_count: 2 },
+    children: [
+      {
+        id: 2,
+        name: 'Mid',
+        count: 2,
+        is_craftable: true,
+        recipe: { output_item_count: 3 },
+        children: [
+          { id: 3, name: 'Leaf', count: 6, buy_price: 10, sell_price: 0, is_craftable: false, children: [] }
+        ]
+      }
+    ]
+  }
+];
 
-main().catch(err => { console.error(err); process.exit(1); });
+const manual = manualTotals(JSON.parse(JSON.stringify(sample)), 1);
+const objs = rebuildTreeArray(JSON.parse(JSON.stringify(sample)));
+recalcAll(objs, 1);
+const totals = getTotals(objs);
+
+assert.deepStrictEqual(totals, manual);
+assert.strictEqual(objs[0].children[0].children[0].countTotal, 2);
+
+console.log('dones-worker recalc test passed');

--- a/tests/items-core-recalc.test.mjs
+++ b/tests/items-core-recalc.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { CraftIngredient } from '../src/js/items-core.js';
+
+const leaf = new CraftIngredient({
+  id: 3,
+  name: 'Leaf',
+  count: 6,
+  buy_price: 10,
+  sell_price: 0,
+  is_craftable: false,
+  recipe: null,
+  children: []
+});
+
+const mid = new CraftIngredient({
+  id: 2,
+  name: 'Mid',
+  count: 2,
+  is_craftable: true,
+  recipe: { output_item_count: 3 },
+  children: [leaf]
+});
+
+const root = new CraftIngredient({
+  id: 1,
+  name: 'Root',
+  count: 1,
+  is_craftable: true,
+  recipe: { output_item_count: 2 },
+  children: [mid]
+});
+
+root.recalc(1, null);
+
+assert.strictEqual(mid.countTotal, 1);
+assert.strictEqual(leaf.countTotal, 2);
+assert.strictEqual(leaf.total_buy, 20);
+assert.strictEqual(root.total_buy, 20);
+
+console.log('items-core recalc test passed');


### PR DESCRIPTION
## Summary
- adjust ingredient `countTotal` to divide by parent recipe output or multiplier
- add items-core and worker tests for recipes producing multiple outputs
- run updated test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aff319ef808328aac5db1e2d4c9ad2