### PR TITLE
refactor: redraw table via safeRenderTable

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -166,12 +166,7 @@ export async function loadItem(itemId) {
               updatedNodes.push({ id, ing });
             });
           });
-
-          if (typeof recalcAll === 'function') {
-            await recalcAll(window.ingredientObjs, window.globalQty);
-          } else if (window.ingredientObjs?.[0]) {
-            window.ingredientObjs[0].recalc(window.globalQty, null);
-          }
+          await window.safeRenderTable?.();
 
           updatedNodes.forEach(({ id, ing }) => updateState(id, ing));
         };


### PR DESCRIPTION
## Summary
- ensure item price updates trigger a full table re-render using `safeRenderTable`
- remove redundant `recalcAll` call to avoid double computation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07fb78d308328940d66c3f538b4be