### PR TITLE
Render zero countTotal in ingredient rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rm -rf dist/js dist/manifest.json && npm run build:packages && APP_VERSION=v$(git rev-parse --short HEAD) && sed \"s/__APP_VERSION__/$APP_VERSION/\" service-worker.js > service-worker.build.js && npx terser service-worker.build.js -o service-worker.min.js && rm service-worker.build.js && rollup -c",
     "migrate:mongo": "node backend/setup.mongo.js",
     "jobs": "node backend/jobs/index.js",
-    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs",
+    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/item-ui-renderRows.test.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -63,7 +63,7 @@ function renderWiki(name) {
 
 
 // --- Renderizado recursivo de ingredientes ---
-function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentExpanded = true, path = []) {
+export function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentExpanded = true, path = []) {
   // DEPURACIÓN opcional de los radios renderizados
   // ings.forEach((ing, idx) => {
   //   if (nivel > 0) {
@@ -94,7 +94,7 @@ function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentE
       <tr data-state-id="${currentPath}" data-path="${currentPath}" data-ing-id="${ing.id}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img data-src="${ing.icon}" width="32" class="lazy-img" alt=""></td>
         <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
-        <td>${ing.countTotal || ing.count}</td>
+        <td>${ing.countTotal != null ? ing.countTotal : ing.count}</td>
         <td class="item-solo-buy">
           <div>${formatGoldColored(ing.total_buy)}</div>
           <div class="item-solo-precio">${formatGoldColored(ing.buy_price)} <span style="color: #c99b5b">c/u</span></div>

--- a/tests/item-ui-renderRows.test.mjs
+++ b/tests/item-ui-renderRows.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'assert';
+
+// Minimal DOM stubs
+global.window = {};
+global.document = {
+  addEventListener: () => {},
+  getElementById: () => null,
+  querySelectorAll: () => []
+};
+
+global.IntersectionObserver = class {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+};
+
+global.formatGoldColored = (value) => String(value);
+
+const { renderRows } = await import('../src/js/item-ui.js');
+
+const ingredient = {
+  id: 1,
+  _uid: 'uid1',
+  icon: 'icon.png',
+  name: 'Test',
+  countTotal: 0,
+  count: 5,
+  is_craftable: false,
+  children: [],
+  buy_price: 1,
+  sell_price: 2,
+  total_buy: 1,
+  total_sell: 2,
+  total_crafted: null,
+  modeForParentCrafted: null,
+  expanded: false,
+  rarity: 'common'
+};
+
+const html = renderRows([ingredient]);
+
+assert.ok(html.includes('<td>0</td>'));
+assert.ok(!html.includes('<td>5</td>'));
+
+console.log('item-ui renderRows countTotal 0 test passed');


### PR DESCRIPTION
## Summary
- Ensure `renderRows` displays `countTotal` even when zero by using an explicit null check.
- Export `renderRows` and add a unit test verifying zero `countTotal` rendering.
- Include new test in npm script.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0853ad5d48328923c53c773acd560