### PR TITLE
fix: render main item count when countTotal is zero

### DIFF
--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -125,7 +125,7 @@ export function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, 
 // --- Renderizado SOLO del nodo raíz. Prohibido usar mainNode.total_buy, siempre usar getTotals() ---
 // --- Renderizado de la fila principal del ítem (nodo raíz) ---
 // --- SOLO del nodo raíz. Totales siempre desde getTotals(), que devuelve los totales globales calculados por recalcAll ---
-function renderMainItemRow(mainNode) {
+export function renderMainItemRow(mainNode) {
   if (!mainNode) return '';
 
   let childTotals = { totalBuy: 0, totalSell: 0 };
@@ -163,7 +163,7 @@ function renderMainItemRow(mainNode) {
       </td>
 
       <!-- Col 3: Cantidad -->
-      <td>${mainNode.countTotal || mainNode.count}</td>
+      <td>${mainNode.countTotal != null ? mainNode.countTotal : mainNode.count}</td>
 
       <!-- Col 4: Total Compra -->
       <td class="item-solo-buy">

--- a/tests/item-ui-renderRows.test.mjs
+++ b/tests/item-ui-renderRows.test.mjs
@@ -15,8 +15,9 @@ global.IntersectionObserver = class {
 };
 
 global.formatGoldColored = (value) => String(value);
+global.getTotals = () => ({ totalBuy: 1, totalSell: 1, totalCrafted: 1 });
 
-const { renderRows } = await import('../src/js/item-ui.js');
+const { renderRows, renderMainItemRow } = await import('../src/js/item-ui.js');
 
 const ingredient = {
   id: 1,
@@ -42,4 +43,26 @@ const html = renderRows([ingredient]);
 assert.ok(html.includes('<td>0</td>'));
 assert.ok(!html.includes('<td>5</td>'));
 
+// Test for renderMainItemRow with countTotal = 0
+const mainNode = {
+  id: 2,
+  _uid: 'uid2',
+  icon: 'icon.png',
+  name: 'Main',
+  countTotal: 0,
+  count: 7,
+  children: [{}], // triggers getTotals
+  buy_price: 0,
+  sell_price: 0,
+  total_crafted: null,
+  expanded: false,
+  rarity: 'common'
+};
+
+const mainHtml = renderMainItemRow(mainNode);
+
+assert.ok(mainHtml.includes('<td>0</td>'));
+assert.ok(!mainHtml.includes('<td>7</td>'));
+
 console.log('item-ui renderRows countTotal 0 test passed');
+console.log('item-ui renderMainItemRow countTotal 0 test passed');


### PR DESCRIPTION
## Summary
- handle `countTotal = 0` correctly in main item row rendering
- export `renderMainItemRow` and add tests for `countTotal = 0`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b097ebcebc832881c55025c2ee1c90