### PR TITLE
Use unique path keys for state updates

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -153,6 +153,15 @@ export async function loadItem(itemId) {
         const idsArray = Array.from(allIds);
         const applyPrices = async (priceMap) => {
           const updatedNodes = [];
+          const buildPath = (ing) => {
+            const path = [];
+            let current = ing;
+            while (current) {
+              path.unshift(current._uid);
+              current = current._parent;
+            }
+            return path.join('-');
+          };
           priceMap.forEach((data, id) => {
             const ings = findIngredientsById(window.ingredientObjs, Number(id));
             if (!ings.length) return;
@@ -163,7 +172,8 @@ export async function loadItem(itemId) {
                 window._mainBuyPrice = ing.buy_price;
                 window._mainSellPrice = ing.sell_price;
               }
-              updatedNodes.push({ id, ing });
+              const path = buildPath(ing);
+              updatedNodes.push({ path, ing });
             });
           });
           await window.safeRenderTable?.();
@@ -178,7 +188,7 @@ export async function loadItem(itemId) {
             requestAnimationFrame(retry);
           }
 
-          updatedNodes.forEach(({ id, ing }) => updateState(id, ing));
+          updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);
       }, 0);

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -91,7 +91,7 @@ export function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, 
     const rarityClass = typeof getRarityClass === 'function' ? getRarityClass(ing.rarity) : '';
     
     return `
-      <tr data-state-id="${currentPath}" data-path="${currentPath}" data-ing-id="${ing.id}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
+      <tr data-state-id="${currentPath}" data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img data-src="${ing.icon}" width="32" class="lazy-img" alt=""></td>
         <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal != null ? ing.countTotal : ing.count}</td>
@@ -151,7 +151,7 @@ export function renderMainItemRow(mainNode) {
   const expandBtn = `<button class="btn-expand-path" data-path="${mainNode._uid}">${mainNode.expanded ? '-' : '+'}</button>`;
 
   return `
-    <tr data-state-id="${mainNode._uid}" data-path="${mainNode._uid}" data-item-id="${mainNode.id}" data-ing-id="${mainNode.id}" class="ingred-row ${mainNode.expanded ? 'expanded' : ''}">
+    <tr data-state-id="${mainNode._uid}" data-path="${mainNode._uid}" data-item-id="${mainNode.id}" class="ingred-row ${mainNode.expanded ? 'expanded' : ''}">
       <!-- Col 1: Ícono (SIN colspan) -->
       <td class="th-border-left-items">
         <img src="${mainNode.icon}" width="32">
@@ -577,8 +577,8 @@ async function renderItemUI(itemData, marketData) {
     document.getElementById('seccion-totales').innerHTML = '';
     document.getElementById('seccion-comparativa').innerHTML = '';
     document.getElementById('seccion-crafting').innerHTML = renderCraftingSectionUI();
-    document.querySelectorAll('#seccion-crafting tr[data-ing-id]').forEach(row => {
-      const id = row.getAttribute('data-ing-id');
+    document.querySelectorAll('#seccion-crafting tr[data-state-id]').forEach(row => {
+      const id = row.getAttribute('data-state-id');
       register(id, row, (ing) => {
         const buyCell = row.querySelector('.item-solo-buy');
         if (buyCell) buyCell.innerHTML = `<div>${formatGoldColored(ing.total_buy)}</div><div class="item-solo-precio">${formatGoldColored(ing.buy_price)} <span style="color: #c99b5b">c/u</span></div>`;
@@ -712,8 +712,8 @@ async function safeRenderTable() {
 
     // Renderizar de nuevo toda la sección
     seccion.innerHTML = renderCraftingSectionUI();
-    document.querySelectorAll('#seccion-crafting tr[data-ing-id]').forEach(row => {
-      const id = row.getAttribute('data-ing-id');
+    document.querySelectorAll('#seccion-crafting tr[data-state-id]').forEach(row => {
+      const id = row.getAttribute('data-state-id');
       register(id, row, (ing) => {
         const buyCell = row.querySelector('.item-solo-buy');
         if (buyCell) {

--- a/src/js/utils/stateManager.js
+++ b/src/js/utils/stateManager.js
@@ -6,7 +6,7 @@ const observer = new IntersectionObserver(entries => {
     const el = entry.target;
     visibility.set(el, entry.isIntersecting);
     if (entry.isIntersecting) {
-      const id = el.dataset.ingId;
+      const id = el.dataset.stateId || el.dataset.path;
       if (!id) return;
       const list = renderers.get(id);
       if (!list) return;
@@ -21,11 +21,12 @@ const observer = new IntersectionObserver(entries => {
 });
 
 export function register(id, el, renderFn) {
-  el.dataset.ingId = id;
-  let list = renderers.get(String(id));
+  const key = String(id);
+  el.dataset.stateId = key;
+  let list = renderers.get(key);
   if (!list) {
     list = [];
-    renderers.set(String(id), list);
+    renderers.set(key, list);
   }
   list.push({ el, renderFn });
   observer.observe(el);


### PR DESCRIPTION
## Summary
- Register item rows by their `data-state-id` path rather than `data-ing-id`
- Propagate price updates using ingredient path identifiers
- Track state by `stateId` in the state manager

## Testing
- `npm test` *(fails: tsup not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b09ebf270083289d1e2a4ab90cfab3