### PR TITLE
fix: defer price rendering until crafting section ready

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -152,6 +152,10 @@ export async function loadItem(itemId) {
         if (stopPriceUpdater) stopPriceUpdater();
         const idsArray = Array.from(allIds);
         const applyPrices = async (priceMap) => {
+          if (!document.getElementById('seccion-crafting')) {
+            requestAnimationFrame(() => applyPrices(priceMap));
+            return;
+          }
           const updatedNodes = [];
           const buildPath = (ing) => {
             const path = [];
@@ -176,19 +180,9 @@ export async function loadItem(itemId) {
               updatedNodes.push({ path, ing });
             });
           });
-          await window.safeRenderTable?.();
-          if (!document.getElementById('seccion-crafting')) {
-            const retry = () => {
-              if (document.getElementById('seccion-crafting')) {
-                window.safeRenderTable?.();
-              } else {
-                requestAnimationFrame(retry);
-              }
-            };
-            requestAnimationFrame(retry);
-          }
-
+          await recalcAll(window.ingredientObjs, window.globalQty || 1);
           updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
+          await window.safeRenderTable?.();
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);
       }, 0);


### PR DESCRIPTION
## Summary
- Retry price application until crafting container exists
- Recalculate ingredient tree and update state before re-rendering totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f42bd5148328839913a1b6137ca4