### PR TITLE
Register totals for incremental crafting updates

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -182,7 +182,7 @@ export async function loadItem(itemId) {
           });
           await recalcAll(window.ingredientObjs, window.globalQty || 1);
           updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
-          await window.safeRenderTable?.();
+          updateState('totales-crafting', window.getTotals?.());
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);
       }, 0);

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -739,6 +739,27 @@ async function safeRenderTable() {
       });
     });
 
+    // Registrar nodos de totales para actualizaciones incrementales
+    document.querySelectorAll('#totales-crafting').forEach(totEl => {
+      const isUnit = totEl.closest('.table-modern-totales')
+        ?.querySelector('h3')
+        ?.textContent?.includes('unidad');
+      register('totales-crafting', totEl, () => {
+        const totals = getTotals();
+        const divisor = isUnit
+          ? (window._mainRecipeOutputCount && !isNaN(window._mainRecipeOutputCount)
+            ? window._mainRecipeOutputCount
+            : 1)
+          : 1;
+        const buyCell = totEl.querySelector('.item-solo-buy');
+        if (buyCell) buyCell.innerHTML = formatGoldColored(totals.totalBuy / divisor);
+        const sellCell = totEl.querySelector('.item-solo-sell');
+        if (sellCell) sellCell.innerHTML = formatGoldColored(totals.totalSell / divisor);
+        const craftedCell = totEl.querySelector('.item-solo-crafted');
+        if (craftedCell) craftedCell.innerHTML = formatGoldColored(totals.totalCrafted / divisor);
+      });
+    });
+
     // Restaurar el valor del input y el estado de los expandibles
     const newQtyInput = document.getElementById('qty-global');
     if (newQtyInput) {


### PR DESCRIPTION
## Summary
- register totals sections in safeRenderTable so they refresh via state manager
- update crafting totals on price changes without full re-render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f4d4985c83289827590d05b97d84