### PR TITLE
fix: handle zero countTotal in renderRows

### DIFF
--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -96,7 +96,7 @@ export function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, 
       <tr data-state-id="${currentPath}" data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img data-src="${ing.icon}" width="32" class="lazy-img" alt=""></td>
         <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
-        <td>${ing.countTotal != null ? ing.countTotal : ing.count}</td>
+        <td>${ing.countTotal ?? ing.count}</td>
         <td class="item-solo-buy">
           <div>${formatGoldColored(ing.total_buy)}</div>
           <div class="item-solo-precio">${formatGoldColored(ing.buy_price)} <span style="color: #c99b5b">c/u</span></div>

--- a/tests/item-ui-renderRows.test.mjs
+++ b/tests/item-ui-renderRows.test.mjs
@@ -43,6 +43,18 @@ const html = renderRows([ingredient]);
 assert.ok(html.includes('<td>0</td>'));
 assert.ok(!html.includes('<td>5</td>'));
 
+// countTotal undefined should fall back to count
+const ingredientFallback = {
+  ...ingredient,
+  _uid: 'uid1b',
+  countTotal: undefined,
+  count: 4
+};
+
+const htmlFallback = renderRows([ingredientFallback]);
+
+assert.ok(htmlFallback.includes('<td>4</td>'));
+
 // Test for renderMainItemRow with countTotal = 0
 const mainNode = {
   id: 2,


### PR DESCRIPTION
## Summary
- Ensure `renderRows` preserves zero values by using nullish coalescing
- Test that `countTotal = 0` displays correctly and falls back when undefined

## Testing
- `node tests/item-ui-renderRows.test.mjs`
- `npm test` *(fails: tsup missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f741be3883288174553e9b7588d7