### PR TITLE
Ensure crafting totals state is registered before updating

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -183,6 +183,9 @@ export async function loadItem(itemId) {
           });
           await recalcAll(window.ingredientObjs, window.globalQty || 1);
           updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
+          if (!document.querySelector('#totales-crafting[data-state-id]')) {
+            await window.safeRenderTable?.();
+          }
           updateState('totales-crafting', window.getTotals?.());
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);


### PR DESCRIPTION
## Summary
- Check whether the `totales-crafting` state is registered before updating crafting totals
- Render table via `safeRenderTable` when totals state is missing to register it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b104fbdd9483289c69de83e66773e1