### PR TITLE
feat: rerender crafting table after price updates

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -182,10 +182,8 @@ export async function loadItem(itemId) {
             });
           });
           await recalcAll(window.ingredientObjs, window.globalQty || 1);
+          await window.safeRenderTable?.();
           updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
-          if (!document.querySelector('#totales-crafting[data-state-id]')) {
-            await window.safeRenderTable?.();
-          }
           updateState('totales-crafting', window.getTotals?.());
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);


### PR DESCRIPTION
## Summary
- rerender crafting table and totals after price updates
- streamline price application by removing stale rendering check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b10f75606c83289143d8b466820c3b