### PR TITLE
Use _uid as state identifier for item rows

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -158,15 +158,6 @@ export async function loadItem(itemId) {
             return;
           }
           const updatedNodes = [];
-          const buildPath = (ing) => {
-            const path = [];
-            let current = ing;
-            while (current) {
-              path.unshift(current._uid);
-              current = current._parent;
-            }
-            return path.join('-');
-          };
           priceMap.forEach((data, id) => {
             const ings = findIngredientsById(window.ingredientObjs, Number(id));
             if (!ings.length) return;
@@ -177,13 +168,12 @@ export async function loadItem(itemId) {
                 window._mainBuyPrice = ing.buy_price;
                 window._mainSellPrice = ing.sell_price;
               }
-              const path = buildPath(ing);
-              updatedNodes.push({ path, ing });
+              updatedNodes.push(ing);
             });
           });
           await recalcAll(window.ingredientObjs, window.globalQty || 1);
           await window.safeRenderTable?.();
-          updatedNodes.forEach(({ path, ing }) => updateState(path, ing));
+          updatedNodes.forEach(ing => updateState(ing._uid, ing));
           updateState('totales-crafting', window.getTotals?.());
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -66,7 +66,7 @@ export function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, 
     const rarityClass = typeof getRarityClass === 'function' ? getRarityClass(ing.rarity) : '';
     
     return `
-      <tr data-state-id="${currentPath}" data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
+      <tr data-state-id="${ing._uid}" data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img data-src="${ing.icon}" width="32" class="lazy-img" alt=""></td>
         <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal ?? ing.count}</td>


### PR DESCRIPTION
## Summary
- update price updater to track state via ingredient `_uid`
- render item rows with `_uid` based `data-state-id`

## Testing
- `npm test` *(fails: tsup not found)*
- `npm --prefix packages/recipe-nesting install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1103463b08328a6cfe703a0134b8d