### PR TITLE
Clarify getTotals usage in item UI

### DIFF
--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -1,4 +1,8 @@
-// GW2 Item Tracker v2 - UI Y PRESENTACIÓN (item-ui.js)
+/**
+ * GW2 Item Tracker v2 - UI Y PRESENTACIÓN (item-ui.js)
+ *
+ * getTotals() siempre devuelve los totales globales calculados por recalcAll y no acepta parámetros.
+ */
 
 import {
   showSkeleton,
@@ -10,8 +14,6 @@ import {
 } from './ui-helpers.js';
 import { register, update as updateState } from './utils/stateManager.js';
 import { initLazyImages, observeSection } from './utils/lazyLoader.js';
-
-// getTotals() siempre devuelve los totales globales calculados por recalcAll y no acepta parámetros.
 
 // Helpers para el input de cantidad global y mensajes de error se
 // comparten ahora desde ui-helpers.js


### PR DESCRIPTION
## Summary
- Document in item-ui header that getTotals always returns global totals
- Ensure getTotals is consistently invoked without arguments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11588ef0c8328b5b786d0a25116fe