### PR TITLE
Ensure crafting totals update after table re-render

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -174,7 +174,6 @@ export async function loadItem(itemId) {
           await recalcAll(window.ingredientObjs, window.globalQty || 1);
           await window.safeRenderTable?.();
           updatedNodes.forEach(ing => updateState(ing._uid, ing));
-          updateState('totales-crafting', window.getTotals?.());
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);
       }, 0);

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -736,6 +736,7 @@ async function safeRenderTable() {
         if (craftedCell) craftedCell.innerHTML = formatGoldColored(totals.totalCrafted / divisor);
       });
     });
+    updateState('totales-crafting', getTotals());
 
     // Restaurar el valor del input y el estado de los expandibles
     const newQtyInput = document.getElementById('qty-global');


### PR DESCRIPTION
## Summary
- Render updated crafting table before updating state
- Trigger initial totals update inside `safeRenderTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b122de193c832898f16de197ed9595