### PR TITLE
refactor: rely on safeRenderTable for recalculation

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -171,7 +171,6 @@ export async function loadItem(itemId) {
               updatedNodes.push(ing);
             });
           });
-          await recalcAll(window.ingredientObjs, window.globalQty || 1);
           await window.safeRenderTable?.();
           updatedNodes.forEach(ing => updateState(ing._uid, ing));
         };


### PR DESCRIPTION
## Summary
- remove redundant `recalcAll` call in `applyPrices` so `safeRenderTable` handles recalculation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1240d78a8832894e48623afc7974f