### PR TITLE
fix: split crafting totals state identifiers

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -172,6 +172,11 @@ export async function loadItem(itemId) {
             });
           });
           await window.safeRenderTable?.();
+          const totals = window.getTotals?.();
+          if (totals) {
+            updateState('totales-crafting-global', totals);
+            updateState('totales-crafting-unit', totals);
+          }
           updatedNodes.forEach(ing => updateState(ing._uid, ing));
         };
         stopPriceUpdater = startPriceUpdater(idsArray, applyPrices);

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -721,8 +721,8 @@ async function safeRenderTable() {
       const isUnit = totEl.closest('.table-modern-totales')
         ?.querySelector('h3')
         ?.textContent?.includes('unidad');
-      register('totales-crafting', totEl, () => {
-        const totals = getTotals();
+      const stateId = isUnit ? 'totales-crafting-unit' : 'totales-crafting-global';
+      register(stateId, totEl, (totals) => {
         const divisor = isUnit
           ? (window._mainRecipeOutputCount && !isNaN(window._mainRecipeOutputCount)
             ? window._mainRecipeOutputCount
@@ -736,7 +736,9 @@ async function safeRenderTable() {
         if (craftedCell) craftedCell.innerHTML = formatGoldColored(totals.totalCrafted / divisor);
       });
     });
-    updateState('totales-crafting', getTotals());
+    const totals = getTotals();
+    updateState('totales-crafting-global', totals);
+    updateState('totales-crafting-unit', totals);
 
     // Restaurar el valor del input y el estado de los expandibles
     const newQtyInput = document.getElementById('qty-global');


### PR DESCRIPTION
## Summary
- use specific IDs for crafting total tables to distinguish global and unit views
- update price-applier to refresh global and unit totals separately

## Testing
- `npm test` *(fails: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b124f469f08328acb02f53fdd6dd90