### PR TITLE
refactor: update recipe nesting imports

### DIFF
--- a/packages/recipe-calculation/src/cheapestTree.ts
+++ b/packages/recipe-calculation/src/cheapestTree.ts
@@ -6,7 +6,7 @@ import {
   NestedRecipe,
   BasicCurrencyComponent,
   BasicItemComponent,
-} from '@gw2efficiency/recipe-nesting'
+} from 'recipe-nesting'
 
 export function cheapestTree(
   amount: number,

--- a/packages/recipe-calculation/src/craftingSteps.ts
+++ b/packages/recipe-calculation/src/craftingSteps.ts
@@ -1,4 +1,4 @@
-import { Prerequisites } from '@gw2efficiency/recipe-nesting'
+import { Prerequisites } from 'recipe-nesting'
 import { RecipeTreeWithCraftFlags } from './types'
 
 const MYSTIC_CLOVER_ID = 19675

--- a/packages/recipe-calculation/src/types.ts
+++ b/packages/recipe-calculation/src/types.ts
@@ -1,4 +1,4 @@
-import type { NestedRecipe as NestedRecipeTree } from '@gw2efficiency/recipe-nesting'
+import type { NestedRecipe as NestedRecipeTree } from 'recipe-nesting'
 
 type ExtendRecipeTree<TBaseTree, TProperties> = Omit<TBaseTree, 'type' | 'components'> & {
   type: 'Recipe' | 'Item' | 'Currency'

--- a/packages/recipe-calculation/tsconfig.json
+++ b/packages/recipe-calculation/tsconfig.json
@@ -13,7 +13,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "incremental": true,
+    "incremental": false,
 
     // Type-Checking Options
     "lib": ["esnext"],


### PR DESCRIPTION
## Summary
- adjust imports in recipe-calculation to use `recipe-nesting` package
- disable incremental TypeScript build to support tsup

## Testing
- `npm --prefix packages/recipe-nesting run build`
- `npm --prefix packages/recipe-calculation run build`
- `npm run build` *(fails: CLOUDFLARE_ZONE_ID and CLOUDFLARE_TOKEN env vars are required)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dac541fc8328a5748b51f7532400