### PR TITLE
Ensure CraftIngredient methods survive deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "rm -rf dist/js dist/manifest.json && npm run build:packages && APP_VERSION=v$(git rev-parse --short HEAD) && sed \"s/__APP_VERSION__/$APP_VERSION/\" service-worker.js > service-worker.build.js && npx terser service-worker.build.js -o service-worker.min.js && rm service-worker.build.js && rollup -c",
     "migrate:mongo": "node backend/setup.mongo.js",
     "jobs": "node backend/jobs/index.js",
-    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/item-ui-renderRows.test.mjs",
+    "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/craft-ingredient-mode.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/item-ui-renderRows.test.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",

--- a/src/js/dones.js
+++ b/src/js/dones.js
@@ -1,4 +1,5 @@
 import { showSkeleton, hideSkeleton } from './ui-helpers.js';
+import { restoreCraftIngredientPrototypes } from './items-core.js';
 const { fetchItemData, fetchPriceData } = window.DonesCore || {};
 // js/dones.js
 
@@ -159,6 +160,7 @@ function runCostsWorker(ingredientTree, globalQty) {
 async function buildWorkerTree(ings) {
   const { ingredientTree } = await runDonesWorker(ings);
   const { updatedTree, totals } = await runCostsWorker(ingredientTree, 1);
+  restoreCraftIngredientPrototypes(updatedTree, null);
   return { tree: updatedTree, totals };
 }
 

--- a/tests/craft-ingredient-mode.test.mjs
+++ b/tests/craft-ingredient-mode.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import { CraftIngredient, restoreCraftIngredientPrototypes } from '../src/js/items-core.js';
+
+global.window = { globalQty: 1 };
+
+const child = new CraftIngredient({
+  id: 2,
+  name: 'Child',
+  count: 1,
+  buy_price: 5,
+  sell_price: 10,
+  is_craftable: false,
+  recipe: null,
+  children: []
+});
+
+const root = new CraftIngredient({
+  id: 1,
+  name: 'Root',
+  count: 1,
+  is_craftable: true,
+  recipe: { output_item_count: 1 },
+  children: [child]
+});
+
+root.recalc(1, null);
+
+const serialized = JSON.parse(JSON.stringify([root]));
+restoreCraftIngredientPrototypes(serialized, null);
+
+const revivedChild = serialized[0].children[0];
+
+assert.doesNotThrow(() => {
+  revivedChild.setMode('sell');
+  revivedChild.setMode('crafted');
+  revivedChild.setMode('buy');
+});
+
+console.log('craft ingredient mode toggle test passed');


### PR DESCRIPTION
## Summary
- Restore CraftIngredient prototypes after any ingredient tree deserialization
- Rehydrate worker results and StorageUtils loads so mode toggling works
- Cover CraftIngredient prototype restoration with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e24ad9208328948d9f4b5a9dd252