### PR TITLE
Clone response before parsing to avoid consuming body

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -31,7 +31,11 @@ class GuildWars2API {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-      const data = await response.json();
+
+      // Clone the response to parse the body without consuming the original
+      const cloned = response.clone();
+      const data = await cloned.json();
+
       if (useCache) {
         setCached(cacheKey, data, this.CACHE_DURATION);
       }


### PR DESCRIPTION
## Summary
- Clone fetch responses in `_fetchWithCache` and parse JSON from the clone to prevent multiple body reads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b22b444f188328bad7afbf5d05cd74