### PR TITLE
Adjust component cost for multi-output recipes

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -3230,8 +3230,9 @@ class LegendaryCraftingBase {
       const sellPrice = component.sellPrice > 0 ? component.sellPrice * component.count : 0;
       if ((buyPrice === 0 || sellPrice === 0) && component.components && component.components.length > 0) {
         const compPrices = this.calculateComponentsPrice(component);
-        const scaledBuy = compPrices.buy * component.count;
-        const scaledSell = compPrices.sell * component.count;
+        const divisor = component.recipe?.output_item_count || component.parentMultiplier || 1;
+        const scaledBuy = (compPrices.buy / divisor) * component.count;
+        const scaledSell = (compPrices.sell / divisor) * component.count;
         return {
           buy: totals.buy + (buyPrice > 0 ? buyPrice : scaledBuy),
           sell: totals.sell + (sellPrice > 0 ? sellPrice : scaledSell)

--- a/tests/calculateComponentsPrice.test.mjs
+++ b/tests/calculateComponentsPrice.test.mjs
@@ -49,4 +49,36 @@ const mixedTree = {
 }
 assert.deepStrictEqual(calc.calculateComponentsPrice(mixedTree), { buy: 13, sell: 18 })
 
+// Component with recipe output count > 1
+const multiOutputTree = {
+  components: [
+    {
+      buyPrice: 0,
+      sellPrice: 0,
+      count: 2,
+      recipe: { output_item_count: 3 },
+      components: [
+        { buyPrice: 3, sellPrice: 6, count: 3, components: [] }
+      ]
+    }
+  ]
+}
+assert.deepStrictEqual(calc.calculateComponentsPrice(multiOutputTree), { buy: 6, sell: 12 })
+
+// Component using parentMultiplier fallback
+const parentMultiplierTree = {
+  components: [
+    {
+      buyPrice: 0,
+      sellPrice: 0,
+      count: 2,
+      parentMultiplier: 4,
+      components: [
+        { buyPrice: 4, sellPrice: 8, count: 4, components: [] }
+      ]
+    }
+  ]
+}
+assert.deepStrictEqual(calc.calculateComponentsPrice(parentMultiplierTree), { buy: 8, sell: 16 })
+
 console.log('calculateComponentsPrice test passed')


### PR DESCRIPTION
## Summary
- Correct component price calculation by dividing nested costs by recipe output or parent multiplier before scaling by quantity
- Extend tests to cover multi-output recipes and parentMultiplier handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b250f646fc8328be7ef29b204823ec