### PR TITLE
fix: persist parent multiplier in item tree

### DIFF
--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -436,6 +436,7 @@ export function createCraftIngredientFromRecipe(recipe, parentMultiplier = 1, pa
     sell_price: recipe.sell_price || 0,
     is_craftable: recipe.is_craftable || false,
     children: [],
+    parentMultiplier,
     _parentId: parentUid
   });
   if (recipe.children && recipe.children.length > 0) {


### PR DESCRIPTION
## Summary
- preserve `parentMultiplier` when building CraftIngredient nodes so cost calculations respect recipe output counts

## Testing
- `node - <<'NODE'
import { CraftIngredient } from './src/js/items-core.js';
const leaf = new CraftIngredient({id:3, name:'Leaf', count:6, buy_price:10, sell_price:0, is_craftable:false, recipe:null, children:[]});
const mid = new CraftIngredient({id:2, name:'Mid', count:2, is_craftable:true, recipe:null, parentMultiplier:3, children:[leaf]});
leaf._parent = mid;
const root = new CraftIngredient({id:1, name:'Root', count:1, is_craftable:true, recipe:{ output_item_count:2 }, children:[mid]});
mid._parent = root;
root.recalc(1,null);
console.log('leaf total_buy', leaf.total_buy);
console.log('root total_buy', root.total_buy);
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b259c2cf048328a046b24b398f5b82