### PR TITLE
Restore legacy recalc quantity logic

### DIFF
--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -70,8 +70,7 @@ export class CraftIngredient {
     if (isRoot) {
       this.countTotal = this.count * globalQty;
     } else {
-      const parentOutput = parent.recipe?.output_item_count || parent.parentMultiplier || 1;
-      this.countTotal = (parent.countTotal * this.count) / parentOutput;
+      this.countTotal = parent.countTotal * this.count;
     }
 
     if (this.children && this.children.length > 0) {

--- a/tests/dones-worker.test.mjs
+++ b/tests/dones-worker.test.mjs
@@ -4,8 +4,7 @@ import { rebuildTreeArray, recalcAll, getTotals } from '../src/js/workers/costsW
 function manualTotals(tree, globalQty) {
   function traverse(node, parent) {
     const parentCount = parent ? parent.countTotal : globalQty;
-    const divisor = parent ? (parent.recipe?.output_item_count || parent.parentMultiplier || 1) : 1;
-    const countTotal = parent ? (parentCount * node.count) / divisor : node.count * globalQty;
+    const countTotal = parent ? parentCount * node.count : node.count * globalQty;
     let totalBuy = (node.buy_price || 0) * countTotal;
     let totalSell = (node.sell_price || 0) * countTotal;
     if (Array.isArray(node.children)) {
@@ -80,6 +79,6 @@ recalcAll(objs, 1);
 const totals = getTotals(objs);
 
 assert.deepStrictEqual(totals, manual);
-assert.strictEqual(objs[0].children[0].children[0].countTotal, 2);
+assert.strictEqual(objs[0].children[0].children[0].countTotal, 12);
 
 console.log('dones-worker recalc test passed');

--- a/tests/items-core-recalc.test.mjs
+++ b/tests/items-core-recalc.test.mjs
@@ -32,9 +32,9 @@ const root = new CraftIngredient({
 
 root.recalc(1, null);
 
-assert.strictEqual(mid.countTotal, 1);
-assert.strictEqual(leaf.countTotal, 2);
-assert.strictEqual(leaf.total_buy, 20);
-assert.strictEqual(root.total_buy, 20);
+assert.strictEqual(mid.countTotal, 2);
+assert.strictEqual(leaf.countTotal, 12);
+assert.strictEqual(leaf.total_buy, 120);
+assert.strictEqual(root.total_buy, 120);
 
 console.log('items-core recalc test passed');


### PR DESCRIPTION
## Summary
- Stop dividing child totals by parent recipe output in `CraftIngredient.recalc`
- Update recalc-related tests for the restored accumulation behavior

## Testing
- `npm test`
- `node - <<'NODE' ...` (new vs. old output comparison)


------
https://chatgpt.com/codex/tasks/task_e_68b2818e00808328b694de84740cf224