### PR TITLE
Normalize ingredient tree worker output

### DIFF
--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -368,8 +368,15 @@ export async function prepareIngredientTreeData(mainItemId, mainRecipeData) {
     const handleMessage = (event) => {
       ingredientTreeWorker.removeEventListener('message', handleMessage);
       ingredientTreeWorker.removeEventListener('error', handleError);
-      const serialized = event.data?.tree || [];
+      let serialized = event.data?.tree || [];
       ingredientTreeWorker = null;
+      if (!Array.isArray(serialized)) {
+        if (serialized && typeof serialized === 'object') {
+          serialized = Array.isArray(serialized.children) ? serialized.children : [serialized];
+        } else {
+          serialized = [];
+        }
+      }
       const deserialized = serialized.map(obj => createCraftIngredientFromRecipe(obj, obj.parentMultiplier, null));
       restoreCraftIngredientPrototypes(deserialized, null);
       deserialized.forEach(root => root.recalc(window.globalQty, null));

--- a/src/js/workers/ingredientTreeWorker.js
+++ b/src/js/workers/ingredientTreeWorker.js
@@ -13,7 +13,7 @@ self.onmessage = async (e) => {
 async function prepareIngredientTreeData(mainItemId) {
   const rootNested = await fetchWithCache(`/recipe-tree/${mainItemId}`).then((r) => r.json());
   if (!rootNested || !rootNested.components || rootNested.components.length === 0) {
-    return null;
+    return [];
   }
 
   const allItemIds = new Set();
@@ -137,6 +137,6 @@ async function prepareIngredientTreeData(mainItemId) {
   }
 
   const root = convertComponent(rootNested, rootNested.recipe?.output_item_count || 1, null);
-  return root;
+  return root ? root.children || [] : [];
 }
 


### PR DESCRIPTION
## Summary
- ensure `ingredientTreeWorker` returns an array of child nodes
- tolerate single-node payloads when preparing ingredient tree data

## Testing
- `npm test`
- `node demoTree.mjs` (sample tree traversal)


------
https://chatgpt.com/codex/tasks/task_e_68b28537f8748328b639dd56d3d43261