### PR TITLE
Fix unit price calculation for legendary bundles

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -343,8 +343,9 @@ class Ingredient {
 
     // Si todos los componentes tienen precio, actualizamos este ítem
     if (todosTienenPrecio && totalBuy > 0 && !this._priceLoaded) {
-      this._buyPrice = totalBuy;
-      this._sellPrice = totalSell;
+      const unitCount = this.count || 1;
+      this._buyPrice = totalBuy / unitCount;
+      this._sellPrice = totalSell / unitCount;
       this._priceLoaded = true;
     }
 
@@ -761,8 +762,9 @@ class Ingredient3 {
 
     // Si todos los componentes tienen precio, actualizamos este ítem
     if (todosTienenPrecio && totalBuy > 0 && !this._priceLoaded) {
-      this._buyPrice = totalBuy;
-      this._sellPrice = totalSell;
+      const unitCount = this.count || 1;
+      this._buyPrice = totalBuy / unitCount;
+      this._sellPrice = totalSell / unitCount;
       this._priceLoaded = true;
     }
 


### PR DESCRIPTION
## Summary
- avoid double-counting prices in legendary bundle `calculateTotals` functions by storing unit prices

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b29d7efdc08328a05f11b9fb3f7131