### PR TITLE
docs: reference manifest for legendary bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the scripts used by the site. Source files are kept in `src/js` and the distributable, minified versions live in `/dist/js/`.
 
-Run `npm run build` to regenerate the bundles. Before compiling it removes any previous output in `dist/js` and `dist/manifest.json` to avoid stale assets. The command uses Rollup to transform each file under `src/js` into `/dist/js/<name>.min.js` and, once finished, runs a CDN purge so clients receive the new routes.
+Run `npm run build` to regenerate the bundles. Before compiling it removes any previous output in `dist/js` and `dist/manifest.json` to avoid stale assets. The command uses Rollup to transform each file under `src/js` into `/dist/js/<name>.min.js` and, once finished, runs a CDN purge so clients receive the new routes. Cada compilación genera un hash nuevo para cada archivo y el resultado final se detalla en `dist/manifest.json`.
 
 ### Build y despliegue
 
@@ -10,11 +10,13 @@ Run `npm run build` to regenerate the bundles. Before compiling it removes any p
 2. Al finalizar, el script `postbuild` invoca `scripts/purge-cdn.js` para invalidar caches de Cloudflare. Define `CLOUDFLARE_ZONE_ID` y `CLOUDFLARE_TOKEN` en el entorno para que la operación tenga éxito.
 3. Publica el contenido de `dist/` en tu servidor o CDN. Los recursos incluyen hashes y deben servirse con `Cache-Control: no-cache`.
 
-Include the bundles from `/dist/js/` in your HTML pages:
+Include the bundles from `/dist/js/` in your HTML pages. Los nombres incluyen un hash y pueden consultarse en `dist/manifest.json`:
 
 ```html
-<script src="/dist/js/bundle-legendary.B3Au4VNc.min.js"></script>
+<script src="/dist/js/bundle-legendary.<hash>.min.js"></script>
 ```
+
+Reemplaza `<hash>` con el valor encontrado en `dist/manifest.json`. Este hash se regenera cada vez que se compila.
 
 ## Pruebas
 
@@ -33,7 +35,7 @@ Las pruebas sólo requieren Node.js y las dependencias instaladas (`mongodb` y `
 
 Los archivos HTML referencian recursos con hash y se sirven con `Cache-Control: no-cache` para que los navegadores obtengan siempre la versión más reciente. Tras cada despliegue, invalida las cachés de la CDN o de Cloudflare para forzar la actualización de estos archivos.
 
-After loading `/dist/js/bundle-legendary.B3Au4VNc.min.js` a global object `window.LegendaryData` becomes available with the following properties:
+After loading `/dist/js/bundle-legendary.<hash>.min.js` (consulta `dist/manifest.json` para obtener el hash actual) a global object `window.LegendaryData` becomes available with the following properties:
 
 - `LEGENDARY_ITEMS` – mapping of first generation legendary items.
 - `LEGENDARY_ITEMS_3GEN` – mapping of third generation legendary weapons.
@@ -43,7 +45,7 @@ After loading `/dist/js/bundle-legendary.B3Au4VNc.min.js` a global object `windo
 Example usage:
 
 ```html
-<script src="/dist/js/bundle-legendary.B3Au4VNc.min.js"></script>
+<script src="/dist/js/bundle-legendary.<hash>.min.js"></script>
 <script>
   const { LEGENDARY_ITEMS } = window.LegendaryData;
   console.log(Object.keys(LEGENDARY_ITEMS));

--- a/dones.html
+++ b/dones.html
@@ -115,7 +115,8 @@
 
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-dones.B6LmXL3c.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
+  <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
+  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
   <script type="module" src="/dist/js/dones.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
   <script>

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -158,7 +158,8 @@
 
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
+  <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
+  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {

--- a/versionAntigua/README.md
+++ b/versionAntigua/README.md
@@ -2,15 +2,17 @@
 
 This repository contains the scripts used by the site. Source files are kept in `src/js` and the distributable, minified versions live in `/dist/js/`.
 
-Run `npm run build` to regenerate the bundles. The command uses Rollup to transform each file under `src/js` into `/dist/js/<name>.min.js`.
+Run `npm run build` to regenerate the bundles. The command uses Rollup to transform each file under `src/js` into `/dist/js/<name>.min.js`. Cada compilación genera un hash nuevo para cada archivo y el resultado final se detalla en `dist/manifest.json`.
 
-Include the bundles from `/dist/js/` in your HTML pages:
+Include the bundles from `/dist/js/` in your HTML pages. Los nombres incluyen un hash y pueden consultarse en `dist/manifest.json`:
 
 ```html
-<script src="/dist/js/bundle-legendary.B3Au4VNc.min.js"></script>
+<script src="/dist/js/bundle-legendary.<hash>.min.js"></script>
 ```
 
-After loading `/dist/js/bundle-legendary.B3Au4VNc.min.js` a global object `window.LegendaryData` becomes available with the following properties:
+Reemplaza `<hash>` con el valor encontrado en `dist/manifest.json`. Este hash se regenera cada vez que se compila.
+
+After loading `/dist/js/bundle-legendary.<hash>.min.js` (consulta `dist/manifest.json` para obtener el hash actual) a global object `window.LegendaryData` becomes available with the following properties:
 
 - `LEGENDARY_ITEMS` – mapping of first generation legendary items.
 - `LEGENDARY_ITEMS_3GEN` – mapping of third generation legendary weapons.
@@ -20,7 +22,7 @@ After loading `/dist/js/bundle-legendary.B3Au4VNc.min.js` a global object `windo
 Example usage:
 
 ```html
-<script src="/dist/js/bundle-legendary.B3Au4VNc.min.js"></script>
+<script src="/dist/js/bundle-legendary.<hash>.min.js"></script>
 <script>
   const { LEGENDARY_ITEMS } = window.LegendaryData;
   console.log(Object.keys(LEGENDARY_ITEMS));

--- a/versionAntigua/dones.html
+++ b/versionAntigua/dones.html
@@ -106,7 +106,8 @@
 
   <script type="module" src="/dist/js/bundle-utils-1.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-dones.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
+  <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
+  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
   <script type="module" src="/dist/js/dones.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.min.js" defer></script>
   <script>

--- a/versionAntigua/leg-craft.html
+++ b/versionAntigua/leg-craft.html
@@ -149,7 +149,8 @@
 
   <script type="module" src="/dist/js/bundle-utils-1.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
+  <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
+  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- document loading legendary bundle using hashed filename from `dist/manifest.json`
- add note about hash regeneration on build
- update HTML templates to refer to manifest for bundle path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3390d229483289d6bbcb1ec73b1d4