### PR TITLE
chore: update legendary bundle hash in views

### DIFF
--- a/dones.html
+++ b/dones.html
@@ -116,7 +116,7 @@
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-dones.B6LmXL3c.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
+  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
   <script type="module" src="/dist/js/dones.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
   <script>

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -159,7 +159,7 @@
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
+  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {

--- a/versionAntigua/dones.html
+++ b/versionAntigua/dones.html
@@ -107,7 +107,7 @@
   <script type="module" src="/dist/js/bundle-utils-1.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-dones.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
+  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
   <script type="module" src="/dist/js/dones.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.min.js" defer></script>
   <script>

--- a/versionAntigua/leg-craft.html
+++ b/versionAntigua/leg-craft.html
@@ -150,7 +150,7 @@
   <script type="module" src="/dist/js/bundle-utils-1.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.<hash>.min.js" defer></script>
+  <script type="module" src="/dist/js/bundle-legendary.B3Au4VNc.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- replace bundle-legendary `<hash>` placeholder with actual `B3Au4VNc` hash in views
- apply same change to legacy HTML copies

## Testing
- `npm install` *(fails: 403 Forbidden for @rollup/plugin-terser)*
- `npm test` *(fails: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3433e1bcc8328ab104fa1593ba54a