### PR TITLE
Normalize Mystic Clover component counts

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -474,9 +474,10 @@ async function createIngredientTree1(itemData, parent = null) {
 
   // Normalizar Trébol místico para usar parentMultiplier
   if (ingredient.id === 19675 && itemData.components) {
-    ingredient.parentMultiplier = ingredient.count;
+    const multiplier = ingredient.count;
+    ingredient.parentMultiplier = multiplier;
     ingredient.count = 1;
-    itemData.components = itemData.components.map(c => ({ ...c, count: 1 }));
+    itemData.components = itemData.components.map(c => ({ ...c, count: c.count / multiplier }));
   }
 
   // Procesar componentes hijos si existen
@@ -969,9 +970,10 @@ async function createIngredientTree3(itemData, parent = null) {
 
   // Normalizar Trébol místico para usar parentMultiplier
   if (ingredient.id === 19675 && itemData.components) {
-    ingredient.parentMultiplier = ingredient.count;
+    const multiplier = ingredient.count;
+    ingredient.parentMultiplier = multiplier;
     ingredient.count = 1;
-    itemData.components = itemData.components.map(c => ({ ...c, count: 1 }));
+    itemData.components = itemData.components.map(c => ({ ...c, count: c.count / multiplier }));
   }
 
   // Procesar componentes hijos si existen


### PR DESCRIPTION
## Summary
- Normalize Mystic Clover (19675) counts in ingredient trees
- Preserve original count via parentMultiplier and adjust child counts accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47fe65c908328ba53db5730e2eff1