### PR TITLE
Simplify ingredient count handling

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -314,7 +314,7 @@ class Ingredient {
    * @returns {Object} Objeto con los totales de compra y venta
    */
   calculateTotals(multiplier = 1) {
-    const effective = multiplier * (this.parentMultiplier ?? this.count);
+    const effective = multiplier * this.count;
 
     // Si no tiene componentes, devolvemos los precios directos
     if (!this.components || this.components.length === 0) {
@@ -497,7 +497,6 @@ function adaptIngredientForWorker(ing) {
     buy_price: ing.buyPrice > 0 ? ing.buyPrice : null,
     sell_price: ing.sellPrice > 0 ? ing.sellPrice : null,
     is_craftable: Array.isArray(ing.components) && ing.components.length > 0,
-    parentMultiplier: ing.parentMultiplier,
     children: Array.isArray(ing.components) ? ing.components.map(adaptIngredientForWorker) : []
   };
 }
@@ -735,7 +734,7 @@ class Ingredient3 {
    * @returns {Object} Objeto con los totales de compra y venta
    */
   calculateTotals(multiplier = 1) {
-    const effective = multiplier * (this.parentMultiplier ?? this.count);
+    const effective = multiplier * this.count;
 
     // Si no tiene componentes, devolvemos los precios directos
     if (!this.components || this.components.length === 0) {
@@ -3231,9 +3230,8 @@ class LegendaryCraftingBase {
       const sellPrice = component.sellPrice > 0 ? component.sellPrice * component.count : 0;
       if ((buyPrice === 0 || sellPrice === 0) && component.components && component.components.length > 0) {
         const compPrices = this.calculateComponentsPrice(component);
-        const divisor = component.recipe?.output_item_count || component.parentMultiplier || 1;
-        const scaledBuy = (compPrices.buy / divisor) * component.count;
-        const scaledSell = (compPrices.sell / divisor) * component.count;
+        const scaledBuy = compPrices.buy * component.count;
+        const scaledSell = compPrices.sell * component.count;
         return {
           buy: totals.buy + (buyPrice > 0 ? buyPrice : scaledBuy),
           sell: totals.sell + (sellPrice > 0 ? sellPrice : scaledSell)

--- a/src/js/utils/recipeUtils.js
+++ b/src/js/utils/recipeUtils.js
@@ -7,7 +7,7 @@
 /**
  * Transforma una receta de la API al formato esperado por CraftIngredient
  */
-window.transformRecipeToIngredient = async function(recipe, count = 1, parentMultiplier = 1) {
+window.transformRecipeToIngredient = async function(recipe, count = 1) {
     try {
         if (!recipe || !recipe.output_item_id) {
             console.error('[ERROR] Receta inválida o sin output_item_id:', recipe);
@@ -33,7 +33,6 @@ window.transformRecipeToIngredient = async function(recipe, count = 1, parentMul
             icon: outputBundle.item.icon || '',
             rarity: outputBundle.item.rarity,
             count: count,
-            parentMultiplier: parentMultiplier,
             buy_price: prices.buy_price || 0,
             sell_price: prices.sell_price || 0,
             is_craftable: recipe.type !== 'GuildConsumable',
@@ -65,7 +64,6 @@ window.transformRecipeToIngredient = async function(recipe, count = 1, parentMul
                     icon: itemDetails.icon || '',
                     rarity: itemDetails.rarity,
                     count: ing.count,
-                    parentMultiplier: recipe.output_item_count,
                     buy_price: prices.buy_price || 0,
                     sell_price: prices.sell_price || 0,
                     is_craftable: !!b.recipe,
@@ -134,7 +132,7 @@ window.loadIngredientTree = async function(ingredient, depth = 0, maxDepth = 3) 
                     const childRecipe = childRecipes[0];
                     if (childRecipe) {
                         // Pasa la receta real y el count correcto
-                        childIngredient = await transformRecipeToIngredient(childRecipe, ing.count, 1);
+                        childIngredient = await transformRecipeToIngredient(childRecipe, ing.count);
                     }
                 }
                 // Si no hay receta, crea un ingrediente básico
@@ -149,7 +147,6 @@ window.loadIngredientTree = async function(ingredient, depth = 0, maxDepth = 3) 
                         icon: itemDetails.icon || '',
                         rarity: itemDetails.rarity,
                         count: ing.count,
-                        parentMultiplier: 1,
                         buy_price: prices.buy_price || 0,
                         sell_price: prices.sell_price || 0,
                         is_craftable: false,

--- a/src/js/workers/ingredientTreeWorker.js
+++ b/src/js/workers/ingredientTreeWorker.js
@@ -81,7 +81,7 @@ async function prepareIngredientTreeData(mainItemId) {
     }
   }
 
-  function convertComponent(node, parentMultiplier, parentId = null) {
+  function convertComponent(node, parentId = null) {
     const itemDetail = allItemsDetailsMap.get(node.id);
     if (!itemDetail) return null;
     const marketInfo = marketDataMap.get(node.id) || {};
@@ -92,26 +92,25 @@ async function prepareIngredientTreeData(mainItemId) {
       children = node.components
         .map((comp) => {
           if (comp.type === 'Recipe') {
-            return convertComponent(comp, node.output || 1, itemDetail.id);
+            return convertComponent(comp, itemDetail.id);
           } else if (comp.type === 'Item') {
             const detail = allItemsDetailsMap.get(comp.id);
             if (!detail) return null;
             const mInfo = marketDataMap.get(comp.id) || {};
-            return {
-              id: detail.id,
-              name: detail.name,
-              icon: detail.icon,
-              rarity: detail.rarity,
-              count: comp.quantity,
-              parentMultiplier: node.output || 1,
-              buy_price: mInfo.buy_price ?? null,
-              sell_price: mInfo.sell_price ?? null,
-              crafted_price: null,
-              is_craftable: false,
-              recipe: null,
-              children: [],
-              _parentId: itemDetail.id,
-            };
+              return {
+                id: detail.id,
+                name: detail.name,
+                icon: detail.icon,
+                rarity: detail.rarity,
+                count: comp.quantity,
+                buy_price: mInfo.buy_price ?? null,
+                sell_price: mInfo.sell_price ?? null,
+                crafted_price: null,
+                is_craftable: false,
+                recipe: null,
+                children: [],
+                _parentId: itemDetail.id,
+              };
           } else {
             return null;
           }
@@ -125,7 +124,6 @@ async function prepareIngredientTreeData(mainItemId) {
       icon: itemDetail.icon,
       rarity: itemDetail.rarity,
       count: node.quantity,
-      parentMultiplier,
       buy_price: marketInfo.buy_price ?? null,
       sell_price: marketInfo.sell_price ?? null,
       crafted_price: null,
@@ -136,7 +134,7 @@ async function prepareIngredientTreeData(mainItemId) {
     };
   }
 
-  const root = convertComponent(rootNested, rootNested.recipe?.output_item_count || 1, null);
+  const root = convertComponent(rootNested, null);
   return root ? root.children || [] : [];
 }
 

--- a/tests/calculateComponentsPrice.test.mjs
+++ b/tests/calculateComponentsPrice.test.mjs
@@ -49,7 +49,7 @@ const mixedTree = {
 }
 assert.deepStrictEqual(calc.calculateComponentsPrice(mixedTree), { buy: 13, sell: 18 })
 
-// Component with recipe output count > 1
+  // Component with recipe output count > 1
 const multiOutputTree = {
   components: [
     {
@@ -63,9 +63,9 @@ const multiOutputTree = {
     }
   ]
 }
-assert.deepStrictEqual(calc.calculateComponentsPrice(multiOutputTree), { buy: 6, sell: 12 })
+  assert.deepStrictEqual(calc.calculateComponentsPrice(multiOutputTree), { buy: 18, sell: 36 })
 
-// Component using parentMultiplier fallback
+  // Component with parentMultiplier property (ignored)
 const parentMultiplierTree = {
   components: [
     {
@@ -79,6 +79,6 @@ const parentMultiplierTree = {
     }
   ]
 }
-assert.deepStrictEqual(calc.calculateComponentsPrice(parentMultiplierTree), { buy: 8, sell: 16 })
+  assert.deepStrictEqual(calc.calculateComponentsPrice(parentMultiplierTree), { buy: 32, sell: 64 })
 
 console.log('calculateComponentsPrice test passed')

--- a/tests/calculateTotals-multiplier.test.mjs
+++ b/tests/calculateTotals-multiplier.test.mjs
@@ -9,34 +9,32 @@ global.document = {
 await import('../src/js/bundle-legendary.js')
 const { Ingredient, Ingredient3 } = window.LegendaryUtils
 
-// Caso 77: cada material se multiplica por 250
+// Caso 77: aplicar multiplicador externo a hojas
 const leaf77 = () => {
-  const ing = new Ingredient(1, 'mat', 'mat', null, 250/77)
+  const ing = new Ingredient(1, 'mat', 'mat', null, 1)
   ing.setPrices(1, 2)
   return ing
 }
 const root77 = new Ingredient(19675, 'Trébol', 'account_bound', null, 1)
-root77.parentMultiplier = 77
 ;[leaf77(), leaf77(), leaf77(), leaf77()].forEach(c => root77.addComponent(c))
-const totals77 = root77.calculateTotals()
-assert.strictEqual(totals77.buy, 4 * 250)
-assert.strictEqual(totals77.sell, 4 * 250 * 2)
+const totals77 = root77.calculateTotals(77)
+assert.strictEqual(totals77.buy, 4 * 77)
+assert.strictEqual(totals77.sell, 4 * 77 * 2)
 root77.components.forEach(c => {
   const t = c.calculateTotals(77)
-  assert.strictEqual(t.buy, 250)
-  assert.strictEqual(t.sell, 500)
+  assert.strictEqual(t.buy, 77)
+  assert.strictEqual(t.sell, 154)
 })
 
-// Caso 38: cada material se multiplica por 38 (1:1)
+// Caso 38: multiplicador diferente
 const leaf38 = () => {
   const ing = new Ingredient3(1, 'mat', 'mat', null, 1)
   ing.setPrices(1, 2)
   return ing
 }
 const root38 = new Ingredient3(19675, 'Trébol', 'account_bound', null, 1)
-root38.parentMultiplier = 38
 ;[leaf38(), leaf38(), leaf38(), leaf38()].forEach(c => root38.addComponent(c))
-const totals38 = root38.calculateTotals()
+const totals38 = root38.calculateTotals(38)
 assert.strictEqual(totals38.buy, 4 * 38)
 assert.strictEqual(totals38.sell, 4 * 38 * 2)
 root38.components.forEach(c => {


### PR DESCRIPTION
## Summary
- remove parentMultiplier from ingredient tree structures
- preserve raw counts when transforming recipes or worker data
- update legendary crafting calculations and tests to use multipliers only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b51798bbac832895f01d602dfe6a0c