### PR TITLE
fix: adjust Mystic Clover totals for 77 and 38 counts

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -325,6 +325,32 @@ class Ingredient {
       };
     }
 
+    // Manejo especial para Trébol místico (ID 19675)
+    if (this.id === 19675) {
+      let totalBuy = 0;
+      let totalSell = 0;
+      let todosTienenPrecio = true;
+
+      let counts = null;
+      if (this.count === 77) {
+        counts = [250, 250, 250, 1500].map(c => c * multiplier);
+      } else if (this.count === 38) {
+        counts = this.components.map(() => 38 * multiplier);
+      }
+
+      if (counts) {
+        this.components.forEach((componente, idx) => {
+          const totalesComponente = componente.calculateTotals(counts[idx] || 0);
+          totalBuy += totalesComponente.buy;
+          totalSell += totalesComponente.sell;
+          if (totalesComponente.buy <= 0 && totalesComponente.sell <= 0) {
+            todosTienenPrecio = false;
+          }
+        });
+        return { buy: totalBuy, sell: totalSell, isCraftable: todosTienenPrecio };
+      }
+    }
+
     // Si tiene componentes, calculamos los totales recursivamente
     let totalBuy = 0;
     let totalSell = 0;
@@ -743,6 +769,32 @@ class Ingredient3 {
         sell: this.sellPrice * effective,
         isCraftable: false
       };
+    }
+
+    // Manejo especial para Trébol místico (ID 19675)
+    if (this.id === 19675) {
+      let totalBuy = 0;
+      let totalSell = 0;
+      let todosTienenPrecio = true;
+
+      let counts = null;
+      if (this.count === 77) {
+        counts = [250, 250, 250, 1500].map(c => c * multiplier);
+      } else if (this.count === 38) {
+        counts = this.components.map(() => 38 * multiplier);
+      }
+
+      if (counts) {
+        this.components.forEach((componente, idx) => {
+          const totalesComponente = componente.calculateTotals(counts[idx] || 0);
+          totalBuy += totalesComponente.buy;
+          totalSell += totalesComponente.sell;
+          if (totalesComponente.buy <= 0 && totalesComponente.sell <= 0) {
+            todosTienenPrecio = false;
+          }
+        });
+        return { buy: totalBuy, sell: totalSell, isCraftable: todosTienenPrecio };
+      }
     }
 
     // Si tiene componentes, calculamos los totales recursivamente


### PR DESCRIPTION
## Summary
- handle Mystic Clover (id 19675) specially in legendary bundle calculations
- skip normalization while summing materials for 77 or 38 clovers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5193314d88328a4b7cd2f15362b12