### PR TITLE
Handle Mystic Clover special counts in ingredient recalculation

### DIFF
--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -66,17 +66,29 @@ export class CraftIngredient {
 
   recalc(globalQty = 1, parent = null) {
     const isRoot = parent == null;
+    const isMysticCloverSpecial = this.id === 19675 && (this.count === 77 || this.count === 38);
     if (isRoot) {
       this.countTotal = this.count * globalQty;
+    } else if (isMysticCloverSpecial) {
+      this.countTotal = this.count;
     } else {
       this.countTotal = parent.countTotal * this.count;
     }
 
     if (this.children && this.children.length > 0) {
-      this.children.forEach(child => child.recalc(globalQty, this));
+      if (isMysticCloverSpecial) {
+        const manualCounts = this.count === 77 ? [250, 250, 250, 1500] : [38, 38, 38, 38];
+        this.children.forEach((child, idx) => {
+          child.countTotal = manualCounts[idx] || 0;
+          child.total_buy = (child.buy_price || 0) * child.countTotal;
+          child.total_sell = (child.sell_price || 0) * child.countTotal;
+        });
+      } else {
+        this.children.forEach(child => child.recalc(globalQty, this));
+      }
     }
 
-    if (isRoot) {
+    if (isRoot || isMysticCloverSpecial) {
       this.total_buy = this.children.reduce((s, c) => s + (c.total_buy || 0), 0);
       this.total_sell = this.children.reduce((s, c) => s + (c.total_sell || 0), 0);
     } else {

--- a/tests/items-core-recalc.test.mjs
+++ b/tests/items-core-recalc.test.mjs
@@ -37,4 +37,48 @@ assert.strictEqual(leaf.countTotal, 12);
 assert.strictEqual(leaf.total_buy, 120);
 assert.strictEqual(root.total_buy, 120);
 
+// Mystic Clover special case: count 77
+const mc77 = new CraftIngredient({
+  id: 19675,
+  name: 'Mystic Clover',
+  count: 77,
+  is_craftable: false,
+  children: [
+    new CraftIngredient({ id: 19976, name: 'Moneda mística', count: 1, buy_price: 2, sell_price: 3, children: [] }),
+    new CraftIngredient({ id: 19721, name: 'Pegote de ectoplasma', count: 1, buy_price: 5, sell_price: 7, children: [] }),
+    new CraftIngredient({ id: 19925, name: 'Esquirla de obsidiana', count: 1, buy_price: 11, sell_price: 13, children: [] }),
+    new CraftIngredient({ id: 20796, name: 'Piedra filosofal', count: 1, buy_price: 17, sell_price: 19, children: [] })
+  ]
+});
+
+mc77.recalc();
+const expected77 = [250, 250, 250, 1500];
+mc77.children.forEach((c, i) => assert.strictEqual(c.countTotal, expected77[i]));
+const buy77 = expected77[0] * 2 + expected77[1] * 5 + expected77[2] * 11 + expected77[3] * 17;
+const sell77 = expected77[0] * 3 + expected77[1] * 7 + expected77[2] * 13 + expected77[3] * 19;
+assert.strictEqual(mc77.total_buy, buy77);
+assert.strictEqual(mc77.total_sell, sell77);
+
+// Mystic Clover special case: count 38
+const mc38 = new CraftIngredient({
+  id: 19675,
+  name: 'Mystic Clover',
+  count: 38,
+  is_craftable: false,
+  children: [
+    new CraftIngredient({ id: 19976, name: 'Moneda mística', count: 1, buy_price: 2, sell_price: 3, children: [] }),
+    new CraftIngredient({ id: 19721, name: 'Pegote de ectoplasma', count: 1, buy_price: 5, sell_price: 7, children: [] }),
+    new CraftIngredient({ id: 19925, name: 'Esquirla de obsidiana', count: 1, buy_price: 11, sell_price: 13, children: [] }),
+    new CraftIngredient({ id: 20796, name: 'Piedra filosofal', count: 1, buy_price: 17, sell_price: 19, children: [] })
+  ]
+});
+
+mc38.recalc();
+const expected38 = [38, 38, 38, 38];
+mc38.children.forEach((c, i) => assert.strictEqual(c.countTotal, expected38[i]));
+const buy38 = expected38[0] * 2 + expected38[1] * 5 + expected38[2] * 11 + expected38[3] * 17;
+const sell38 = expected38[0] * 3 + expected38[1] * 7 + expected38[2] * 13 + expected38[3] * 19;
+assert.strictEqual(mc38.total_buy, buy38);
+assert.strictEqual(mc38.total_sell, sell38);
+
 console.log('items-core recalc test passed');


### PR DESCRIPTION
## Summary
- add special handling for Mystic Clover to assign correct child quantities and totals
- cover 77 and 38 count scenarios with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52c27b6dc8328ad49bd9d9b1fae6a