### PR TITLE
feat: track clover total counts

### DIFF
--- a/tests/calculateTotals-trebol.test.mjs
+++ b/tests/calculateTotals-trebol.test.mjs
@@ -20,8 +20,8 @@ function runTrebolTest(Cls, rootCount, expectedCounts) {
   const sum = expectedCounts.reduce((a, b) => a + b, 0)
   assert.strictEqual(totals.buy, sum)
   assert.strictEqual(totals.sell, sum * 2)
-  root.components.forEach(c => {
-    assert.strictEqual(c.count, rootCount)
+  root.components.forEach((c, i) => {
+    assert.strictEqual(c.countTotal, expectedCounts[i])
   })
 }
 


### PR DESCRIPTION
## Summary
- compute `countTotal` for ingredients and use it to show accurate quantities and pricing
- copy total counts from worker data and display real totals in UI
- adjust components price calculation and clover tests for 77/38 special cases

## Testing
- `npm test` *(fails: tsup not found)*
- `node tests/calculateTotals-trebol.test.mjs`
- `node tests/calculateTotals-multiplier.test.mjs`
- `node tests/calculateComponentsPrice.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b5eb0d97d883288eeae218f0b6c7b0