### PR TITLE
test: verify trebol totals with countTotal

### DIFF
--- a/tests/calculateTotals-trebol.test.mjs
+++ b/tests/calculateTotals-trebol.test.mjs
@@ -20,9 +20,8 @@ function runTrebolTest(Cls, rootCount, expectedCounts) {
   const sum = expectedCounts.reduce((a, b) => a + b, 0)
   assert.strictEqual(totals.buy, sum)
   assert.strictEqual(totals.sell, sum * 2)
-  root.components.forEach((c, i) => {
-    assert.strictEqual(c.countTotal, expectedCounts[i])
-  })
+  const componentCounts = root.components.map((c) => c.countTotal)
+  assert.deepStrictEqual(componentCounts, expectedCounts)
 }
 
 runTrebolTest(Ingredient, 77, [250, 250, 250, 1500])


### PR DESCRIPTION
## Summary
- test calculateTotals trebol using `countTotal`
- assert component counts match expected values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f08f4a6c83288dd4e4454c48e932