### PR TITLE
Ensure Mystic Clover child count is set during recalculation

### DIFF
--- a/src/js/items-core.js
+++ b/src/js/items-core.js
@@ -79,6 +79,7 @@ export class CraftIngredient {
       if (isMysticCloverSpecial) {
         const manualCounts = this.count === 77 ? [250, 250, 250, 1500] : [38, 38, 38, 38];
         this.children.forEach((child, idx) => {
+          child.count = manualCounts[idx] || 0;
           child.countTotal = manualCounts[idx] || 0;
           child.total_buy = (child.buy_price || 0) * child.countTotal;
           child.total_sell = (child.sell_price || 0) * child.countTotal;

--- a/tests/items-core-recalc.test.mjs
+++ b/tests/items-core-recalc.test.mjs
@@ -53,7 +53,10 @@ const mc77 = new CraftIngredient({
 
 mc77.recalc();
 const expected77 = [250, 250, 250, 1500];
-mc77.children.forEach((c, i) => assert.strictEqual(c.countTotal, expected77[i]));
+mc77.children.forEach((c, i) => {
+  assert.strictEqual(c.count, expected77[i]);
+  assert.strictEqual(c.countTotal, expected77[i]);
+});
 const buy77 = expected77[0] * 2 + expected77[1] * 5 + expected77[2] * 11 + expected77[3] * 17;
 const sell77 = expected77[0] * 3 + expected77[1] * 7 + expected77[2] * 13 + expected77[3] * 19;
 assert.strictEqual(mc77.total_buy, buy77);
@@ -75,7 +78,10 @@ const mc38 = new CraftIngredient({
 
 mc38.recalc();
 const expected38 = [38, 38, 38, 38];
-mc38.children.forEach((c, i) => assert.strictEqual(c.countTotal, expected38[i]));
+mc38.children.forEach((c, i) => {
+  assert.strictEqual(c.count, expected38[i]);
+  assert.strictEqual(c.countTotal, expected38[i]);
+});
 const buy38 = expected38[0] * 2 + expected38[1] * 5 + expected38[2] * 11 + expected38[3] * 17;
 const sell38 = expected38[0] * 3 + expected38[1] * 7 + expected38[2] * 13 + expected38[3] * 19;
 assert.strictEqual(mc38.total_buy, buy38);


### PR DESCRIPTION
## Summary
- Set each Mystic Clover child count using manual values before computing totals
- Extend recalc tests to verify child count values for Mystic Clover cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f6fd06e4832899deb0f26853f18d