### PR TITLE
Refactor worker to send costs by uid

### DIFF
--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -2752,10 +2752,10 @@ class LegendaryCraftingBase {
       const adapted = adaptIngredientForWorker(this.currentTree);
       const treeForWorker = [adapted];
       treeForWorker.forEach(_mapQtyToCount);
-      const { updatedTree, totals } = await runCostsWorker(treeForWorker, window.globalQty || 1);
+      const { costs, totals } = await runCostsWorker(treeForWorker, window.globalQty || 1);
       const workerTotalBuy = totals?.totalBuy || 0;
-      if (Array.isArray(updatedTree) && updatedTree[0]) {
-        mergeWorkerTotals(updatedTree[0], this.currentTree);
+      if (Array.isArray(costs)) {
+        mergeWorkerTotals(costs, this.currentTree);
       }
       const localTotalBuy = _sumVisibleBuy(this.currentTree);
       this.workerTotals = totals || { totalBuy: 0, totalSell: 0, totalCrafted: 0 };

--- a/src/js/dones.js
+++ b/src/js/dones.js
@@ -1,5 +1,6 @@
 import { showSkeleton, hideSkeleton } from './ui-helpers.js';
 import { restoreCraftIngredientPrototypes } from './items-core.js';
+import { mergeWorkerTotals } from './utils/mergeWorkerTotals.js';
 const { fetchItemData, fetchPriceData } = window.DonesCore || {};
 // js/dones.js
 
@@ -159,9 +160,12 @@ function runCostsWorker(ingredientTree, globalQty) {
 
 async function buildWorkerTree(ings) {
   const { ingredientTree } = await runDonesWorker(ings);
-  const { updatedTree, totals } = await runCostsWorker(ingredientTree, 1);
-  restoreCraftIngredientPrototypes(updatedTree, null);
-  return { tree: updatedTree, totals };
+  const { costs, totals } = await runCostsWorker(ingredientTree, 1);
+  if (Array.isArray(costs)) {
+    mergeWorkerTotals(costs, ingredientTree);
+  }
+  restoreCraftIngredientPrototypes(ingredientTree, null);
+  return { tree: ingredientTree, totals };
 }
 
 function renderNodeHtml(node, level = 0) {

--- a/src/js/workers/costsWorker.js
+++ b/src/js/workers/costsWorker.js
@@ -55,7 +55,23 @@ ctx.onmessage = (e) => {
   const ingredientObjs = rebuildTreeArray(ingredientTree);
   recalcAll(ingredientObjs, globalQty);
   const totals = getTotals(ingredientObjs);
-  ctx.postMessage({ updatedTree: ingredientObjs, totals });
+  const costs = [];
+  (function collect(nodes) {
+    for (const n of nodes) {
+      costs.push({
+        uid: n._uid,
+        total_buy: n.total_buy,
+        total_sell: n.total_sell,
+        total_crafted: n.total_crafted,
+        crafted_price: n.crafted_price,
+        countTotal: n.countTotal
+      });
+      if (Array.isArray(n.children) && n.children.length) {
+        collect(n.children);
+      }
+    }
+  })(ingredientObjs);
+  ctx.postMessage({ costs, totals });
 };
 
 export { rebuildTreeArray, recalcAll, getTotals };

--- a/tests/mergeWorkerTotals-propagation.test.mjs
+++ b/tests/mergeWorkerTotals-propagation.test.mjs
@@ -26,63 +26,21 @@ const dest = {
   ]
 };
 
-const workerData = {
-  _uid: 1,
-  buy_price: 1,
-  sell_price: 2,
-  total_buy: 10,
-  total_sell: 20,
-  total_crafted: 30,
-  crafted_price: 40,
-  countTotal: 10,
-  children: [
-    {
-      _uid: 2,
-      buy_price: 3,
-      sell_price: 4,
-      total_buy: 0,
-      total_sell: 0,
-      total_crafted: 0,
-      crafted_price: 0,
-      countTotal: 3,
-      children: [
-        {
-          _uid: 3,
-          buy_price: 5,
-          sell_price: 6,
-          total_buy: 0,
-          total_sell: 0,
-          total_crafted: 0,
-          crafted_price: 0,
-          countTotal: 5,
-          children: []
-        }
-      ]
-    },
-    {
-      _uid: 4,
-      buy_price: 7,
-      sell_price: 8,
-      total_buy: 0,
-      total_sell: 0,
-      total_crafted: 0,
-      crafted_price: 0,
-      countTotal: 7,
-      children: []
-    }
-  ]
-};
+const workerData = [
+  { uid: 1, total_buy: 10, total_sell: 20, total_crafted: 30, crafted_price: 40, countTotal: 10 },
+  { uid: 2, total_buy: 0, total_sell: 0, total_crafted: 0, crafted_price: 0, countTotal: 3 },
+  { uid: 3, total_buy: 0, total_sell: 0, total_crafted: 0, crafted_price: 0, countTotal: 5 },
+  { uid: 4, total_buy: 0, total_sell: 0, total_crafted: 0, crafted_price: 0, countTotal: 7 }
+];
 
 mergeWorkerTotals(workerData, dest);
 
-assert.strictEqual(dest.count, 0);
 assert.strictEqual(dest.countTotal, 10);
-assert.strictEqual(dest.buy_price, 1);
-assert.strictEqual(dest.components[0].count, 0);
 assert.strictEqual(dest.components[0].countTotal, 3);
-assert.strictEqual(dest.components[0].buy_price, 3);
 assert.strictEqual(dest.components[0].components[0].countTotal, 5);
 assert.strictEqual(dest.components[1].countTotal, 7);
+assert.strictEqual(dest.count, 0);
+assert.strictEqual(dest.components[0].count, 0);
 assert.strictEqual(dest.components[1].count, 0);
 
 console.log('mergeWorkerTotals propagation test passed');


### PR DESCRIPTION
## Summary
- Costs worker now sends minimal costs array keyed by ingredient uid
- mergeWorkerTotals merges totals using uid-based costs list
- Updated main modules to consume new costs format
- Adjusted test for mergeWorkerTotals propagation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75855344083289b10a6cd5062c93d