### PR TITLE
Insert hashed utils module in HTML entry points

### DIFF
--- a/dones.html
+++ b/dones.html
@@ -114,6 +114,7 @@
   </div>
 
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/dist/js/utils-PEkmbGsx.js" defer></script>
   <script type="module" src="/dist/js/bundle-dones.B6LmXL3c.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
   <script type="module" src="/dist/js/bundle-legendary.btSGyNIl.min.js" defer></script>

--- a/forja-mistica.html
+++ b/forja-mistica.html
@@ -220,6 +220,7 @@
     </main>
   </div>
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/dist/js/utils-PEkmbGsx.js" defer></script>
   <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-forja-mistica.B_m8Dj-2.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-auth-nav.DQtwZThZ.min.js" defer></script>

--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -172,6 +172,7 @@
     </main>
   </div>
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/dist/js/utils-PEkmbGsx.js" defer></script>
   <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
   <script type="module" src="/dist/js/bundle-fractales.C9zaC9ZH.min.js" defer></script>
   <script>

--- a/item.html
+++ b/item.html
@@ -97,6 +97,7 @@
         </div>
       </div>
   <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/dist/js/utils-PEkmbGsx.js" defer></script>
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');


### PR DESCRIPTION
## Summary
- Load `/dist/js/utils-PEkmbGsx.js` after `bundle-utils-1` in public HTML pages so utilities are available before inline scripts.

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bfe5523083288c8f79140f484bcc