### PR TITLE
fix item loader script path

### DIFF
--- a/item.html
+++ b/item.html
@@ -139,7 +139,7 @@
     import('/dist/js/services/recipeService.min.js')
   );
 </script>
-<script type="module" src="/dist/js/item-loader.CPhMCrzV.min.js" defer></script>
+<script type="module" src="/dist/js/item-loader.CrhdKR7P.min.js" defer></script>
   
   <!-- Inicialización -->
   <script>


### PR DESCRIPTION
## Summary
- fix item loader script reference to use latest hashed file

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: tsup not found)


------
https://chatgpt.com/codex/tasks/task_e_68b9072ec0d88328b2fec1656168e6f3