### PR TITLE
Preserve items-core exports and validate loader dependencies

### DIFF
--- a/src/js/item-loader.js
+++ b/src/js/item-loader.js
@@ -30,6 +30,18 @@ async function ensureDeps() {
         cancelItemRequests,
         recalcAll
       } = core);
+      // Validamos que todos los métodos requeridos estén presentes. Si alguno
+      // falta, la build de items-core es incorrecta y el loader no funcionará.
+      if (
+        !prepareIngredientTreeData ||
+        !CraftIngredient ||
+        !setIngredientObjs ||
+        !findIngredientsById ||
+        !cancelItemRequests ||
+        !recalcAll
+      ) {
+        throw new Error('items-core exports missing');
+      }
       ({ preloadPrices } = price);
       ({ getItemBundles } = recipe);
       ({ update: updateState } = state);


### PR DESCRIPTION
## Summary
- ensure Rollup keeps items-core functions by disabling tree-shaking and reserving export names
- validate item-loader receives required items-core methods

## Testing
- `npm test` *(fails: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9109d76ec8328bbd61704830a475d