### PR TITLE
Ensure build keeps existing bundles until rollup succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gw2-project",
   "private": true,
   "scripts": {
-    "build": "rm -rf dist/js dist/manifest.json && npm run build:packages && APP_VERSION=v$(git rev-parse --short HEAD) && sed \"s/__APP_VERSION__/$APP_VERSION/\" service-worker.js > service-worker.build.js && npx terser service-worker.build.js -o service-worker.min.js && rm service-worker.build.js && rollup -c",
+    "build": "bash scripts/build.sh",
     "migrate:mongo": "node backend/setup.mongo.js",
     "jobs": "node backend/jobs/index.js",
     "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/craft-ingredient-mode.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/gw2api-getItemDetails-parallel.test.mjs && node tests/item-ui-renderRows.test.mjs && node tests/calculateTotals-multiplier.test.mjs && node tests/calculateTotals-trebol.test.mjs && node tests/mergeWorkerTotals-propagation.test.mjs",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+TMP_DIR=$(mktemp -d)
+
+restore_previous() {
+  rm -rf dist/js dist/manifest.json
+  if [ -d "$TMP_DIR/js" ]; then mv "$TMP_DIR/js" dist/js; fi
+  if [ -f "$TMP_DIR/manifest.json" ]; then mv "$TMP_DIR/manifest.json" dist/manifest.json; fi
+  rm -rf "$TMP_DIR"
+}
+
+trap restore_previous ERR
+
+# Preserve previous build
+if [ -d dist/js ]; then mv dist/js "$TMP_DIR/js"; fi
+if [ -f dist/manifest.json ]; then mv dist/manifest.json "$TMP_DIR/manifest.json"; fi
+
+# Build packages and service worker
+npm run build:packages
+APP_VERSION=v$(git rev-parse --short HEAD)
+sed "s/__APP_VERSION__/$APP_VERSION/" service-worker.js > service-worker.build.js
+npx terser service-worker.build.js -o service-worker.min.js
+rm service-worker.build.js
+
+# Run rollup
+rollup -c
+
+# Cleanup backup after successful build
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- Move build steps into `scripts/build.sh`
- Update `npm run build` to use script so previous `dist/js` is restored on failure

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9215b5d9c83289f43b385a159841b