### PR TITLE
feat: store build outputs in versioned releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "jobs": "node backend/jobs/index.js",
     "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/craft-ingredient-mode.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/gw2api-getItemDetails-parallel.test.mjs && node tests/item-ui-renderRows.test.mjs && node tests/calculateTotals-multiplier.test.mjs && node tests/calculateTotals-trebol.test.mjs && node tests/mergeWorkerTotals-propagation.test.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
-    "postbuild": "node scripts/update-html.js && npm run purge:cdn",
     "check-assets": "node scripts/check-assets.js",
     "bump:cache": "bash scripts/bump-cache-version.sh",
     "purge:cdn": "node scripts/purge-cdn.js"


### PR DESCRIPTION
## Summary
- build into a temporary `dist-tmp` folder and move artifacts into `releases/<commit>`
- handle release cleanup and CDN purge directly in build script

## Testing
- `npm test`
- `npm run build` *(fails: CLOUDFLARE_ZONE_ID and CLOUDFLARE_TOKEN env vars are required)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6a6a87f4832895756f3d45ceb762