### PR TITLE
Add deployment cleanup, rollback script, and runbook

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,14 @@
+# Runbook de despliegue
+
+## Despliegue
+
+1. Generar los artefactos necesarios.
+2. Ejecutar `bash scripts/deploy.sh [VERSION]`.
+   - Copia los archivos a `releases/[VERSION]` dentro de `/var/www/gw2/static`.
+   - Actualiza el alias `current` para apuntar a la nueva versión.
+   - Elimina los despliegues antiguos con `ls -1t releases | tail -n +3 | xargs rm -rf`.
+   - Purga la caché del CDN.
+
+## Rollback
+
+Ejecutar `bash scripts/rollback.sh <VERSION>` para que el alias `current` vuelva a apuntar a la versión deseada.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,15 +4,14 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/.."; pwd)
 TARGET=/var/www/gw2
 RELEASE=${1:-$(git rev-parse --short HEAD)}
-KEEP=${KEEP:-3}
 
 mkdir -p "$TARGET/static/releases/$RELEASE"
 cp -r dist css img backend "$TARGET/static/releases/$RELEASE/"
 cp .htaccess refresh.php service-worker.min.js version.txt *.html "$TARGET/static/releases/$RELEASE/"
 ln -sfn "$TARGET/static/releases/$RELEASE" "$TARGET/static/current"
 
-cd "$TARGET/static/releases"
-ls -1t | tail -n +$((KEEP+1)) | xargs -r rm -rf
+cd "$TARGET/static"
+ls -1t releases | tail -n +3 | xargs rm -rf
 
 # Purge CDN cache to force revalidation of assets
 node "$ROOT/scripts/purge-cdn.js"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+TARGET=/var/www/gw2
+RELEASE=${1:?"Uso: $0 <VERSION>"}
+
+ln -sfn "$TARGET/static/releases/$RELEASE" "$TARGET/static/current"


### PR DESCRIPTION
## Summary
- Clean old releases during deployment
- Add rollback helper script
- Document deployment and rollback steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba709d36b883288994031929d98310