### PR TITLE
Remove hashed script references from templates post-build

### DIFF
--- a/aurene.html
+++ b/aurene.html
@@ -79,7 +79,7 @@
   
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -89,7 +89,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -58,6 +58,6 @@
             }
         };
     </script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/builds.html
+++ b/builds.html
@@ -75,7 +75,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -85,7 +85,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/compare-craft.html
+++ b/compare-craft.html
@@ -72,7 +72,7 @@
 
 
   
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
 
   <!-- Modal del Buscador fuera de .container para igualar a index.html -->
   <div id="search-modal" class="search-modal hidden">
@@ -99,7 +99,7 @@
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      openSearchModal('/dist/js/search-modal-compare-craft.Ds_WAp9-.min.js');
+      openSearchModal('/static/current/js/search-modal-compare-craft.min.js');
     });
     closeBtn.addEventListener('click', closeSearchModal);
     modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
@@ -109,12 +109,12 @@
   });
   </script>
 
-  <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js" defer></script>
+  <script type="module" src="/static/current/js/tabs.min.js" defer></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js" defer></script>
   <!-- Nuevos módulos separados -->
-  <script type="module" src="/dist/js/items-core.DMXEDbc5.min.js?v=BsFSl0er" defer></script>
-  <script type="module" src="/dist/js/ui-helpers.min.js" defer></script>
-  <script type="module" src="/dist/js/compare-ui.min.js" defer></script>
+  <script type="module" src="/static/current/js/items-core.min.js?v=BsFSl0er" defer></script>
+  <script type="module" src="/static/current/js/ui-helpers.min.js" defer></script>
+  <script type="module" src="/static/current/js/compare-ui.min.js" defer></script>
 
   <script>
   // Override global de selectItem para integración con el modal en compare-craft
@@ -143,7 +143,7 @@
 };
 
   </script>
-<script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+<script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -153,9 +153,9 @@
   });
 </script>
 
-<script type="module" src="/dist/js/storageUtils.min.js" defer></script>
+<script type="module" src="/static/current/js/storageUtils.min.js" defer></script>
 <!-- Manejadores de comparativa (guardar comparativa) -->
-<script type="module" src="/dist/js/compareHandlers.min.js" defer></script>
+<script type="module" src="/static/current/js/compareHandlers.min.js" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     if (window.comparativa &&
@@ -164,6 +164,6 @@
     }
   });
 </script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/cuenta.html
+++ b/cuenta.html
@@ -100,7 +100,7 @@
   </div>
 
   <!-- Scripts -->
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -110,8 +110,8 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/storageUtils.min.js"></script>
-  <script type="module" src="/dist/js/cuenta.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/storageUtils.min.js"></script>
+  <script type="module" src="/static/current/js/cuenta.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/dominios.html
+++ b/dominios.html
@@ -68,7 +68,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -78,7 +78,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/dones.html
+++ b/dones.html
@@ -113,12 +113,12 @@
     </main>
   </div>
 
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-dones.B6LmXL3c.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-dones.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.DIH8x-x6.min.js" defer></script>
-  <script type="module" src="/dist/js/dones.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-legendary.min.js" defer></script>
+  <script type="module" src="/static/current/js/dones.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -131,8 +131,8 @@
   <script type="module">
     window.addEventListener('DOMContentLoaded', async () => {
       try {
-        await import('/dist/js/feedback-modal.BaGBwUid.min.js');
-        await import('/dist/js/sw-register.Wot8iBZe.min.js');
+        await import('/static/current/js/feedback-modal.min.js');
+        await import('/static/current/js/sw-register.min.js');
       } catch (e) {
         console.error('Error loading optional modules', e);
       }

--- a/end-game.html
+++ b/end-game.html
@@ -93,7 +93,7 @@
       });
     });
   </script>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -103,7 +103,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/end-of-dragons.html
+++ b/end-of-dragons.html
@@ -68,7 +68,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -78,7 +78,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/forja-mistica.html
+++ b/forja-mistica.html
@@ -219,10 +219,10 @@
       <!-- FIN extras -->
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
-  <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-forja-mistica.B_m8Dj-2.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
+  <script type="module" src="/static/current/js/tabs.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-forja-mistica.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -232,7 +232,7 @@
     });
   </script>
 
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js" defer></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js" defer></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -171,9 +171,9 @@
 <!-- fin EXTRAS -->
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
-  <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-fractales.C9zaC9ZH.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
+  <script type="module" src="/static/current/js/tabs.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-fractales.min.js" defer></script>
   <script>
     // Usar las utilidades expuestas en window para evitar duplicar identificadores
     document.addEventListener('DOMContentLoaded', async () => {
@@ -206,7 +206,7 @@
       await renderTodo();
     });
   </script>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -216,7 +216,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js" defer></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js" defer></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/guias.html
+++ b/guias.html
@@ -65,7 +65,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -75,7 +75,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
 
         function loadUtils() {
           if (!utilsPromise) {
-            utilsPromise = import('/dist/js/bundle-utils-1.By0Xs4MH.min.js');
+            utilsPromise = import('/static/current/js/bundle-utils-1.min.js');
           }
           return utilsPromise;
         }
@@ -139,7 +139,7 @@
         openBtn.addEventListener('click', async function(e) {
           e.preventDefault();
           await loadUtils();
-          openSearchModal('/dist/js/search-modal.D0pWReq9.min.js');
+          openSearchModal('/static/current/js/search-modal.min.js');
         });
         const safeClose = async (...args) => {
           await loadUtils();
@@ -312,7 +312,7 @@
   <script type="module">
     window.addEventListener('DOMContentLoaded', async () => {
       try {
-        await import('/dist/js/bundle-auth-nav.CqZGatN4.min.js');
+        await import('/static/current/js/bundle-auth-nav.min.js');
         window.Auth?.initAuth?.();
       } catch (e) {
         console.error('Error loading auth module', e);
@@ -335,7 +335,7 @@
   <script type="module">
     window.addEventListener('DOMContentLoaded', async () => {
       try {
-        await import('/dist/js/sw-register.Wot8iBZe.min.js');
+        await import('/static/current/js/sw-register.min.js');
       } catch (e) {
         console.error('SW registration failed', e);
       }

--- a/item.html
+++ b/item.html
@@ -96,7 +96,7 @@
           <div id="modal-results" class="item-list"></div>
         </div>
       </div>
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle.min.js" defer></script>
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');
@@ -104,7 +104,7 @@
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      openSearchModal('/dist/js/search-modal.D0pWReq9.min.js');
+      openSearchModal('/static/current/js/search.min.js');
     });
     closeBtn.addEventListener('click', closeSearchModal);
     modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
@@ -114,7 +114,7 @@
   });
   </script>
 
-<script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+<script type="module" src="/static/current/js/bundle.min.js" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -124,21 +124,21 @@
   });
 </script>
 
-<script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js" defer></script>
-<script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
-<script type="module" src="/dist/js/utils/recipeUtils.min.js" defer></script>
-<script type="module" src="/dist/js/item-mejores.min.js" defer></script>
-<script type="module" src="/dist/js/itemHandlers.min.js" defer></script>
-<script type="module" src="/dist/js/storageUtils.min.js" defer></script>
-<script type="module" src="/dist/js/ui-helpers.min.js" defer></script>
-<script type="module" src="/dist/js/item-ui.min.js" defer></script>
-<script type="module" src="/dist/js/items-core.DMXEDbc5.min.js?v=BsFSl0er" defer></script>
+<script type="module" src="/static/current/js/feedback.min.js" defer></script>
+<script type="module" src="/static/current/js/tabs.min.js" defer></script>
+<script type="module" src="/static/current/js/utils/recipeUtils.min.js" defer></script>
+<script type="module" src="/static/current/js/item.min.js" defer></script>
+<script type="module" src="/static/current/js/itemHandlers.min.js" defer></script>
+<script type="module" src="/static/current/js/storageUtils.min.js" defer></script>
+<script type="module" src="/static/current/js/ui.min.js" defer></script>
+<script type="module" src="/static/current/js/item.min.js" defer></script>
+<script type="module" src="/static/current/js/items.min.js?v=BsFSl0er" defer></script>
 <script type="module">
-  import('/dist/js/services-Bc-4z6yK.js').catch(() =>
-    import('/dist/js/services/recipeService.min.js')
+  import('/static/current/js/services.js').catch(() =>
+    import('/static/current/js/services/recipeService.min.js')
   );
 </script>
-<script type="module" src="/dist/js/item-loader.CPhMCrzV.min.js" defer></script>
+<script type="module" src="/static/current/js/item.min.js" defer></script>
   
   <!-- Inicialización -->
   <script>
@@ -163,6 +163,6 @@
         }
     });
   </script>
-    <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+    <script type="module" src="/static/current/js/sw.min.js"></script>
 </body>
 </html>

--- a/janthir-wilds.html
+++ b/janthir-wilds.html
@@ -54,7 +54,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -64,7 +64,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -156,10 +156,10 @@
   </div>
   </main>
 
-  <script type="module" src="/dist/js/bundle-utils-1.By0Xs4MH.min.js" defer></script>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
   <!-- Consulta dist/manifest.json para obtener el hash actual; se regenera en cada compilación -->
-  <script type="module" src="/dist/js/bundle-legendary.DIH8x-x6.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-legendary.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -169,9 +169,9 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/tabs.DUiiG-cO.min.js" defer></script>
+  <script type="module" src="/static/current/js/tabs.min.js" defer></script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js" defer></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js" defer></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/legendarios.html
+++ b/legendarios.html
@@ -324,7 +324,7 @@ function scrollToLegendario(id) {
 
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -334,7 +334,7 @@ function scrollToLegendario(id) {
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -71,7 +71,7 @@
         </p>
         <p style="margin-top:20px;"><a href="/">Volver al inicio</a></p>
     </div>
-    <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+    <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
     <script>
       // Inicializar autenticación cuando el DOM esté listo
       document.addEventListener('DOMContentLoaded', function() {
@@ -80,6 +80,6 @@
         }
       });
     </script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/lore.html
+++ b/lore.html
@@ -66,7 +66,7 @@
      
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -76,7 +76,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/mundo-viviente-3.html
+++ b/mundo-viviente-3.html
@@ -76,7 +76,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -86,7 +86,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/mundo-viviente-4.html
+++ b/mundo-viviente-4.html
@@ -73,7 +73,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -83,7 +83,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -78,7 +78,7 @@
         <p>Si tienes dudas sobre esta política, puedes contactarnos a través del correo: <a href="mailto:contacto@gw2item.com">contacto@gw2item.com</a></p>
     </div>
 
-    <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+    <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/random.html
+++ b/random.html
@@ -108,7 +108,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -118,7 +118,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/sangre-y-hielo.html
+++ b/sangre-y-hielo.html
@@ -68,7 +68,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -78,7 +78,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,3 +33,6 @@ npm run purge:cdn || true
 # Move build to releases
 mv dist "$BUILD_DIR"
 mv "$BUILD_DIR" "$TARGET_DIR"
+
+# Restore html templates to non-hashed script references
+node scripts/update-templates.js

--- a/scripts/update-templates.js
+++ b/scripts/update-templates.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const htmlFiles = fs.readdirSync(rootDir).filter(f => f.endsWith('.html'));
+
+const jsRegex = /\/dist\/js\/((?:[\w-]+\/)*)([\w-]+?)(?:[.-][^\/"']+)?\.min\.js(\?[^"']*)?/g;
+const jsPlainRegex = /\/dist\/js\/((?:[\w-]+\/)*)([\w-]+?)(?:[.-][^\/"']+)?\.js(\?[^"']*)?/g;
+
+for (const file of htmlFiles) {
+  const filePath = path.join(rootDir, file);
+  const content = fs.readFileSync(filePath, 'utf8');
+  let updated = content.replace(jsRegex, '/static/current/js/$1$2.min.js$3');
+  updated = updated.replace(jsPlainRegex, '/static/current/js/$1$2.js$3');
+  if (updated !== content) {
+    fs.writeFileSync(filePath, updated);
+  }
+}

--- a/secrets-of-the-obscure.html
+++ b/secrets-of-the-obscure.html
@@ -63,7 +63,7 @@
       </section>
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -73,7 +73,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>

--- a/sellos-y-runas.html
+++ b/sellos-y-runas.html
@@ -39,7 +39,7 @@
      
     </main>
   </div>
-  <script type="module" src="/dist/js/bundle-auth-nav.CqZGatN4.min.js"></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -49,7 +49,7 @@
     });
   </script>
   
-  <script type="module" src="/dist/js/feedback-modal.BaGBwUid.min.js"></script>
-  <script type="module" src="/dist/js/sw-register.Wot8iBZe.min.js"></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js"></script>
+  <script type="module" src="/static/current/js/sw-register.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `scripts/update-templates.js` to rewrite `/dist/js/*.js` references in HTML to `/static/current/js` without hash
- run template update script at the end of `scripts/build.sh` so templates revert to non-hashed paths
- update existing HTML views to point at `/static/current/js/*.min.js`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@rollup%2fplugin-terser)*
- `npm test` *(fails: sh: 1: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba731bf7408328a82dd71ff51f604f