### PR TITLE
Simplify JS build outputs and release deployment verification

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,10 +5,22 @@ ROOT=$(cd "$(dirname "$0")/.."; pwd)
 TARGET=/var/www/gw2
 RELEASE=${1:-$(git rev-parse --short HEAD)}
 
-mkdir -p "$TARGET/static/releases/$RELEASE"
-cp -r dist css img backend "$TARGET/static/releases/$RELEASE/"
+mkdir -p "$TARGET/static/releases/$RELEASE/js"
+cp -r dist/js "$TARGET/static/releases/$RELEASE/"
+cp -r css img backend "$TARGET/static/releases/$RELEASE/"
 cp .htaccess refresh.php service-worker.min.js version.txt *.html "$TARGET/static/releases/$RELEASE/"
 ln -sfn "$TARGET/static/releases/$RELEASE" "$TARGET/static/current"
+
+MANIFEST="$ROOT/dist/manifest.json"
+jq -r 'to_entries[] | "\(.key) \(.value)"' "$MANIFEST" | while read -r path hash; do
+  name=$(basename "$path")
+  dest="$TARGET/static/releases/$RELEASE/js/$name"
+  if [ ! -f "$dest" ]; then
+    echo "Missing JS asset: $name"
+    exit 1
+  fi
+  ln -sfn "$name" "$TARGET/static/releases/$RELEASE/js/${name%.min.js}.$hash.min.js"
+done
 
 cd "$TARGET/static"
 ls -1t releases | tail -n +3 | xargs rm -rf


### PR DESCRIPTION
## Summary
- Build JS bundles without filename hashes and produce a verification manifest mapping `/static/js/*.min.js` to content hashes.
- Deploy script now copies JS bundles to versioned release directories, verifies manifest entries, and creates hashed symlinks.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a9a73b083289435530b7c15febd