### PR TITLE
feat: check worker availability in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,4 +17,9 @@ jobs:
       - run: rm -rf dist/js dist/manifest.json
       - run: npm run build
       - run: npm run check-assets
+      - run: npm run check-workers
+      - uses: actions/upload-artifact@v4
+        with:
+          name: workers-report
+          path: workers-report.json
       - run: npm run purge:cdn

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npm --prefix packages/recipe-nesting run build && node tests/dones-worker.test.mjs && node tests/items-core-recalc.test.mjs && node tests/craft-ingredient-mode.test.mjs && node tests/price-helper-map.test.mjs && node tests/recipe-nesting-map.test.mjs && node tests/recipe-nesting-cycle.test.mjs && node tests/recipe-nesting-guildupgrade.test.mjs && node tests/recipe-tree-cache.test.mjs && node tests/recipeTree.test.js && node tests/calculateComponentsPrice.test.mjs && node tests/check-assets.mjs && node tests/gw2api-getItemDetails-parallel.test.mjs && node tests/item-ui-renderRows.test.mjs && node tests/calculateTotals-multiplier.test.mjs && node tests/calculateTotals-trebol.test.mjs && node tests/mergeWorkerTotals-propagation.test.mjs",
     "build:packages": "npm --prefix packages/recipe-nesting run build && npm --prefix packages/recipe-calculation run build",
     "check-assets": "node scripts/check-assets.js",
+    "check-workers": "node scripts/check-workers.js",
     "bump:cache": "bash scripts/bump-cache-version.sh",
     "purge:cdn": "node scripts/purge-cdn.js"
   },

--- a/scripts/check-workers.js
+++ b/scripts/check-workers.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({ default: f }) => f(...args)));
+
+const rootDir = path.join(__dirname, '..');
+const releasesDir = path.join(rootDir, 'releases');
+
+if (!fs.existsSync(releasesDir)) {
+  console.error('Releases directory not found');
+  process.exit(1);
+}
+
+const versions = fs.readdirSync(releasesDir).filter((name) => fs.statSync(path.join(releasesDir, name)).isDirectory());
+
+if (versions.length === 0) {
+  console.error('No release versions found');
+  process.exit(1);
+}
+
+const version = versions[0];
+const workersDir = path.join(releasesDir, version, 'workers');
+
+if (!fs.existsSync(workersDir)) {
+  console.error('Workers directory not found in release');
+  process.exit(1);
+}
+
+const workers = fs.readdirSync(workersDir).filter((f) => f.endsWith('.js'));
+const baseUrl = 'https://gw2item.com/static/current/workers';
+const report = [];
+let allOk = true;
+
+(async () => {
+  for (const worker of workers) {
+    const url = `${baseUrl}/${worker}`;
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      report.push({ worker, status: res.status });
+      if (res.status !== 200) {
+        allOk = false;
+      }
+    } catch (err) {
+      report.push({ worker, status: 'error' });
+      allOk = false;
+    }
+  }
+
+  const reportPath = path.join(rootDir, 'workers-report.json');
+  fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+  if (!allOk) {
+    console.error('Some workers failed to fetch');
+    process.exit(1);
+  } else {
+    console.log('All workers fetched successfully');
+  }
+})();


### PR DESCRIPTION
## Summary
- add `check-workers` npm script to verify worker endpoints
- verify workers during publish workflow and upload report artifact

## Testing
- `npm test`
- `npm run check-workers` *(fails: Some workers failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68ba863c255483289fff59f6620ad409