### PR TITLE
feat: verify release assets against manifest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ jobs:
       - run: rm -rf dist/js dist/manifest.json
       - run: npm run build
       - run: npm run check-assets
+      - uses: actions/upload-artifact@v4
+        with:
+          name: assets-report
+          path: assets-report.json
       - run: npm run check-workers
       - uses: actions/upload-artifact@v4
         with:

--- a/asset-manifest.json
+++ b/asset-manifest.json
@@ -1,0 +1,19 @@
+[
+  "js/bundle-auth-nav.CqZGatN4.min.js",
+  "js/bundle-dones.B6LmXL3c.min.js",
+  "js/bundle-fractales.C9zaC9ZH.min.js",
+  "js/bundle-forja-mistica.B_m8Dj-2.min.js",
+  "js/bundle-legendary.DIH8x-x6.min.js",
+  "js/bundle-utils-1.By0Xs4MH.min.js",
+  "js/item-loader.CPhMCrzV.min.js",
+  "js/tabs.DUiiG-cO.min.js",
+  "js/feedback-modal.BaGBwUid.min.js",
+  "js/leg-craft-tabs.CY76y-Sh.min.js",
+  "js/search-modal.D0pWReq9.min.js",
+  "js/search-modal-core.C9MAtSBQ.min.js",
+  "js/search-modal-compare-craft.Ds_WAp9-.min.js",
+  "js/sw-register.Wot8iBZe.min.js",
+  "js/ingredientTreeWorker.wY9O56L9.js",
+  "js/costsWorker.BsFSl0er.js",
+  "js/items-core.DMXEDbc5.min.js"
+]

--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -2,29 +2,67 @@ const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.join(__dirname, '..');
+const releasesDir = path.join(rootDir, 'releases');
+const inventoryPath = path.join(rootDir, 'asset-manifest.json');
 
-const htmlFiles = fs.readdirSync(rootDir).filter(f => f.endsWith('.html'));
-const missing = [];
+let version = process.argv[2];
 
-for (const htmlFile of htmlFiles) {
-  const filePath = path.join(rootDir, htmlFile);
-  const content = fs.readFileSync(filePath, 'utf8');
-  const matches = content.match(/\/dist\/js\/[^"'\s)]+\.js/g) || [];
-  for (const ref of new Set(matches)) {
-    const relative = ref.replace(/^\//, '');
-    const assetPath = path.join(rootDir, relative);
-    if (!fs.existsSync(assetPath)) {
-      missing.push(`${ref} referenced in ${htmlFile}`);
+function resolveReleaseDir() {
+  if (version) {
+    return path.join(releasesDir, version);
+  }
+  if (!fs.existsSync(releasesDir)) {
+    console.error(`Releases directory not found: ${releasesDir}`);
+    process.exit(1);
+  }
+  const dirs = fs.readdirSync(releasesDir).filter(f =>
+    fs.statSync(path.join(releasesDir, f)).isDirectory()
+  );
+  if (dirs.length !== 1) {
+    console.error('Specify a version or ensure exactly one release in releases/.');
+    process.exit(1);
+  }
+  version = dirs[0];
+  return path.join(releasesDir, version);
+}
+
+function loadInventory() {
+  if (!fs.existsSync(inventoryPath)) {
+    console.error(`Inventory not found: ${inventoryPath}`);
+    process.exit(1);
+  }
+  const data = fs.readFileSync(inventoryPath, 'utf8');
+  return JSON.parse(data);
+}
+
+function main() {
+  const releaseDir = resolveReleaseDir();
+  const inventory = loadInventory();
+  const missing = [];
+
+  for (const relPath of inventory) {
+    const filePath = path.join(releaseDir, relPath);
+    if (!fs.existsSync(filePath)) {
+      missing.push(relPath);
     }
   }
+
+  const report = {
+    version,
+    status: missing.length ? 'fail' : 'ok',
+    missing,
+  };
+  fs.writeFileSync(path.join(rootDir, 'assets-report.json'), JSON.stringify(report, null, 2));
+
+  if (missing.length) {
+    console.error('Missing assets:');
+    for (const m of missing) {
+      console.error(' -', m);
+    }
+    process.exit(1);
+  } else {
+    console.log(`All assets present for release ${version}.`);
+  }
 }
 
-if (missing.length > 0) {
-  console.error('Missing JS assets:');
-  for (const m of missing) {
-    console.error(' -', m);
-  }
-  process.exit(1);
-} else {
-  console.log('All referenced JS assets exist.');
-}
+main();


### PR DESCRIPTION
## Summary
- add asset inventory file with hashed paths
- check release dirs against inventory and generate report
- upload asset integrity report in publish workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8893e7448328b1853a52b40288ab