### PR TITLE
Document CDN cache headers and validation steps

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -9,6 +9,21 @@
    - Elimina los despliegues antiguos con `ls -1t releases | tail -n +3 | xargs rm -rf`.
    - Purga la caché del CDN.
 
+3. Verificar que el CDN respeta las cabeceras `Cache-Control` enviadas por el
+   origen. Asegúrate de no tener reglas en el CDN que las sobrescriban.
+
+   - `/static/current/*` debe responder con `Cache-Control: no-cache, must-revalidate`.
+   - `/static/<VERSIÓN>/*` debe responder con `Cache-Control: public, max-age=31536000, immutable`.
+
+   Puedes comprobarlo con herramientas del CDN o con `curl`:
+
+   ```bash
+   curl -I -H 'Cache-Control: max-age=0' https://<dominio>/static/current/app.js
+   curl -I -H 'Cache-Control: max-age=0' https://<dominio>/static/123/app.js
+   ```
+
+   Ambas respuestas deben incluir las cabeceras mencionadas.
+
 ## Rollback
 
 Ejecutar `bash scripts/rollback.sh <VERSION>` para que el alias `current` vuelva a apuntar a la versión deseada.

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,10 @@ http {
         server_name example.com;
         root /var/www/gw2/current;
 
+        # The CDN is expected to honor the Cache-Control headers from this origin
+        # configuration. Any CDN-side caching rules that override these headers
+        # should remain disabled so that the policies below take effect.
+
         # Política de íconos: los íconos se descargan desde la CDN de ArenaNet
         # o pueden servirse desde este servidor ajustando las URLs.
 
@@ -39,11 +43,13 @@ http {
         # Do not cache files under /static/current/
         location ^~ /static/current/ {
             add_header Cache-Control "no-cache, must-revalidate";
+            expires -1;
         }
 
         # Strong cache for versioned static files
         location ~ ^/static/[^/]+/ {
             add_header Cache-Control "public, max-age=31536000, immutable";
+            expires 1y;
         }
 
         # Cache static assets for 30 days


### PR DESCRIPTION
## Summary
- ensure nginx sends correct Cache-Control headers for static assets
- document CDN cache rules and curl-based verification in deployment runbook

## Testing
- `npm test`
- `curl -I -H 'Cache-Control: max-age=0' http://localhost:3000/static/current/app.js`
- `curl -I -H 'Cache-Control: max-age=0' http://localhost:3000/static/123/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba897fa41c8328af2307e2be70cbc7