### PR TITLE
feat: log legacy routes and 404s

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -27,3 +27,12 @@
 ## Rollback
 
 Ejecutar `bash scripts/rollback.sh <VERSION>` para que el alias `current` vuelva a apuntar a la versión deseada.
+
+## Monitorización de rutas obsoletas
+
+- El archivo `/var/log/nginx/legacy.log` registra accesos a rutas antiguas como `/dist/`.
+- El archivo `/var/log/nginx/404.log` captura todas las respuestas 404.
+- Revisar ambos logs de forma mensual.
+- Si una ruta antigua recibe menos de 5 accesos por semana durante cuatro semanas consecutivas, programar la eliminación de su rewrite o redirección.
+- Las rewrites o redirecciones temporales deben eliminarse, como máximo, antes del **30/06/2025**.
+- Documentar el plan de retiro en este runbook o en un issue del repositorio cuando los accesos sean insignificantes.

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,21 @@ http {
         application/javascript js mjs;
     }
 
+    # Log format for tracking legacy paths and 404 responses
+    log_format legacy '$remote_addr - $remote_user [$time_local] "$request" $status "$http_referer" "$http_user_agent"';
+
+    # Flag 404 responses for dedicated logging
+    map $status $log_404 {
+        default 0;
+        404 1;
+    }
+
+    # Flag accesses to legacy routes such as /dist/
+    map $request_uri $log_legacy {
+        default 0;
+        ~^/dist/ 1;
+    }
+
     server {
         listen 80;
         server_name example.com;
@@ -68,5 +83,9 @@ http {
             add_header Cache-Control "no-cache";
             try_files $uri $uri/ /index.html;
         }
+
+        # Dedicated access logs for legacy routes and 404 errors
+        access_log /var/log/nginx/legacy.log legacy if=$log_legacy;
+        access_log /var/log/nginx/404.log legacy if=$log_404;
     }
 }


### PR DESCRIPTION
## Summary
- log 404 responses and `/dist/` requests to dedicated files in nginx
- document review cadence and retirement thresholds for legacy paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8ad72a34832892157ce68550da03