### PR TITLE
Add pre/post activation checks

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,7 +9,6 @@ mkdir -p "$TARGET/static/releases/$RELEASE/js"
 cp -r dist/js "$TARGET/static/releases/$RELEASE/"
 cp -r css img backend "$TARGET/static/releases/$RELEASE/"
 cp .htaccess refresh.php service-worker.min.js version.txt *.html "$TARGET/static/releases/$RELEASE/"
-ln -sfn "$TARGET/static/releases/$RELEASE" "$TARGET/static/current"
 
 MANIFEST="$ROOT/dist/manifest.json"
 jq -r 'to_entries[] | "\(.key) \(.value)"' "$MANIFEST" | while read -r path hash; do
@@ -21,6 +20,15 @@ jq -r 'to_entries[] | "\(.key) \(.value)"' "$MANIFEST" | while read -r path hash
   fi
   ln -sfn "$name" "$TARGET/static/releases/$RELEASE/js/${name%.min.js}.$hash.min.js"
 done
+
+# Run checks before switching the current alias
+bash "$ROOT/scripts/pre-activate.sh" "$RELEASE"
+
+# Activate new release
+ln -sfn "$TARGET/static/releases/$RELEASE" "$TARGET/static/current"
+
+# Verify that critical assets are reachable
+bash "$ROOT/scripts/post-activate.sh"
 
 cd "$TARGET/static"
 ls -1t releases | tail -n +3 | xargs rm -rf

--- a/scripts/post-activate.sh
+++ b/scripts/post-activate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${1:-http://localhost}
+TARGET=${TARGET:-/var/www/gw2}
+
+curl -fsS "$BASE_URL/static/current/js/app.min.js" >/dev/null
+curl -fsS "$BASE_URL/static/current/css/styles.min.css" >/dev/null
+
+WORKER_DIR="$TARGET/static/current/workers"
+shopt -s nullglob
+for file in "$WORKER_DIR"/*.js; do
+  name=$(basename "$file")
+  curl -fsS "$BASE_URL/static/current/workers/$name" >/dev/null
+done
+shopt -u nullglob

--- a/scripts/pre-activate.sh
+++ b/scripts/pre-activate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=${1:?"Usage: $0 <VERSION>"}
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+node "$DIR/check-assets.js" "$VERSION"
+node "$DIR/check-workers.js"


### PR DESCRIPTION
## Summary
- add pre-activation script to verify assets and worker scripts
- add post-activation script to curl critical resources and ensure they respond
- hook pre- and post-activation scripts into deploy.sh around alias update

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@rollup%2fplugin-terser)*
- `npm test` *(fails: tsup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf389380c8328b1c4a80ec1e14e91