### PR TITLE
Fix script references on item page

### DIFF
--- a/item.html
+++ b/item.html
@@ -96,7 +96,7 @@
           <div id="modal-results" class="item-list"></div>
         </div>
       </div>
-  <script type="module" src="/static/current/js/bundle.min.js" defer></script>
+    <script type="module" src="/static/current/js/bundle-utils-1.min.js" defer></script>
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');
@@ -104,7 +104,7 @@
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      openSearchModal('/static/current/js/search.min.js');
+        openSearchModal('/static/current/js/search-modal.min.js');
     });
     closeBtn.addEventListener('click', closeSearchModal);
     modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
@@ -114,7 +114,7 @@
   });
   </script>
 
-<script type="module" src="/static/current/js/bundle.min.js" defer></script>
+  <script type="module" src="/static/current/js/bundle-auth-nav.min.js" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -124,21 +124,19 @@
   });
 </script>
 
-<script type="module" src="/static/current/js/feedback.min.js" defer></script>
+  <script type="module" src="/static/current/js/feedback-modal.min.js" defer></script>
 <script type="module" src="/static/current/js/tabs.min.js" defer></script>
 <script type="module" src="/static/current/js/utils/recipeUtils.min.js" defer></script>
-<script type="module" src="/static/current/js/item.min.js" defer></script>
-<script type="module" src="/static/current/js/itemHandlers.min.js" defer></script>
-<script type="module" src="/static/current/js/storageUtils.min.js" defer></script>
-<script type="module" src="/static/current/js/ui.min.js" defer></script>
-<script type="module" src="/static/current/js/item.min.js" defer></script>
-<script type="module" src="/static/current/js/items.min.js?v=BsFSl0er" defer></script>
-<script type="module">
-  import('/static/current/js/services.js').catch(() =>
-    import('/static/current/js/services/recipeService.min.js')
-  );
-</script>
-<script type="module" src="/static/current/js/item.min.js" defer></script>
+  <script type="module" src="/static/current/js/item-loader.min.js" defer></script>
+  <script type="module" src="/static/current/js/item-ui.min.js" defer></script>
+  <script type="module" src="/static/current/js/item-mejores.min.js" defer></script>
+  <script type="module" src="/static/current/js/itemHandlers.min.js" defer></script>
+  <script type="module" src="/static/current/js/storageUtils.min.js" defer></script>
+  <script type="module">
+    import('/static/current/js/services-Bc-4z6yK.js').catch(() =>
+      import('/static/current/js/services/recipeService.min.js')
+    );
+  </script>
   
   <!-- Inicialización -->
   <script>
@@ -163,7 +161,7 @@
         }
     });
   </script>
-    <script type="module" src="/static/current/js/sw.min.js"></script>
+    <script type="module" src="/static/current/js/sw-register.min.js"></script>
   <!-- partial:assets -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace obsolete script references in item.html with existing bundles from dist/js
- Update search modal and service worker imports
- Remove unused duplicates and point to hashed services module

## Testing
- `npm run check-assets`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba30fc7d08328b0f93d5b2e20df31