### PR TITLE
Fix asset references to use existing bundles

### DIFF
--- a/templates/partials/assets.html
+++ b/templates/partials/assets.html
@@ -1,5 +1,5 @@
-<script type="module" src="/static/current/js/vendor.min.js"></script>
-<script type="module" src="/static/current/js/app.min.js"></script>
-<link rel="stylesheet" href="/static/current/css/styles.min.css">
+<script type="module" src="/static/current/js/bundle-utils-1.min.js"></script>
+<script type="module" src="/static/current/js/bundle-auth-nav.min.js"></script>
+<link rel="stylesheet" href="/css/global-gw.min.css">
 <script type="module" src="/static/current/js/sw-register.min.js"></script>
 


### PR DESCRIPTION
## Summary
- load bundle-utils-1 and bundle-auth-nav instead of missing vendor/app bundles
- point shared assets partial at existing global-gw.min.css stylesheet

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bba73a8d7c8328a801a041479cd713