### PR TITLE
fix: apuntar guias.html a global-gw.css

### DIFF
--- a/guias.html
+++ b/guias.html
@@ -5,9 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/img/favicon.ico" sizes="16x16" type="image/x-icon">
   <title>Tablero de Videos - GW2</title>
-  <link rel="stylesheet" href="css/global.css">
-  <link rel="stylesheet" href="css/styles-2.css">
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/global-gw.css">
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-1YJ4M39JP3"></script>
 <script>


### PR DESCRIPTION
## Summary
- replace obsolete CSS links in `guias.html` with existing `global-gw.css`

## Testing
- `npm run build`
- `curl -I http://localhost:8000/guias.html`
- `curl -I http://localhost:8000/css/global-gw.css`
- `curl -I http://localhost:8000/css/global-gw.min.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbabee0d5483288e4e37c6e40e2d8a